### PR TITLE
Add scripts to publish the latest draft on the websites

### DIFF
--- a/_scripts/publish-to-github.sh
+++ b/_scripts/publish-to-github.sh
@@ -1,0 +1,44 @@
+#! /bin/bash
+ant all.doc
+rc=$?
+if [[ $rc != 0 ]] ; then
+    echo "ERROR: Specification build failed!"
+    exit $rc
+fi
+
+pushd build
+# clone hibernate.github.io in _tmp if not present
+if [ ! -d "beanvalidation.github.io" ];
+then
+  git clone --depth 1 git@github.com:beanvalidation/beanvalidation.github.io.git
+  rc=$?
+  if [[ $rc != 0 ]] ; then
+    echo "ERROR: beanvalidation/beanvalidation.github.io cannot be cloned!"
+    exit $rc
+  fi
+fi
+
+cd beanvalidation.github.io
+git fetch origin
+git reset --hard origin/master
+
+# Synchronize the content with the latest-draft folder of the site
+rsync -av --delete --exclude ".git" ../en/html_single/ latest-draft/spec/ 
+rc=$?
+if [[ $rc != 0 ]] ; then
+    echo "ERROR: Latest-draft sync failed!"
+    exit $rc
+fi
+
+git add -A .
+if git commit -m "Publish latest-draft of beanvalidation-spec" ;
+then
+ git push origin master;
+ rc=$?
+fi
+popd
+if [[ $rc != 0 ]] ; then
+  echo "ERROR: Cannot push on site repository!"
+  exit $rc
+fi
+

--- a/_scripts/publish-to-staging.sh
+++ b/_scripts/publish-to-staging.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Make sure there was no update to the used dependencies (if not, this is just a quick version check for Bundler)
+ant all.doc
+rc=$?
+if [[ $rc != 0 ]] ; then
+    echo "ERROR: Specification build failed!"
+    exit $rc
+fi
+
+rsync --delete -avh build/en/html_single/ ci.hibernate.org:/var/www/staging-beanvalidation.org/latest-draft/spec/
+rc=$?
+if [[ $rc != 0 ]] ; then
+    echo "ERROR: Specification sync failed!"
+    exit $rc
+fi


### PR DESCRIPTION
Added the scripts to sync the latest draft on beanvalidation.org

@Sanne  can you check that they are still compatible with the things you are doing?
@emmanuelbernard should we keep them on master or should we create a production/staging branch.
I would keep them on master.