### PR TITLE
BVAL-513 Add the Google Analytics marker to the spec

### DIFF
--- a/docinfo/index-docinfo-footer.html
+++ b/docinfo/index-docinfo-footer.html
@@ -1,0 +1,9 @@
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-24703879-1', 'auto');
+  ga('send', 'pageview');
+</script>

--- a/sources/index.asciidoc
+++ b/sources/index.asciidoc
@@ -8,6 +8,8 @@
 :anchor:
 :toc: left
 :numbered:
+:docinfo:
+:docinfodir: ../docinfo
 
 [preface]
 include::sources/{license}.asciidoc[]


### PR DESCRIPTION
* https://hibernate.atlassian.net/browse/BVAL-513

For an unknown reason, I didn't get to put the marker id in the configuration. Looks like there's something weird going on.

For now, this will do.

It looks like it's an issue to put the docinfo files outside the asciidoc source directory (I have the same issue with the HV documentation). Moreover, there is an additional issue here as putting the docinfo file in the source directory does not work at all.