### PR TITLE
BVAL-560 Mention Oracle instead of Sun in the evaluation license

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -7,7 +7,7 @@
 	<property name="bv.version" value="2.0.0-SNAPSHOT" /><!-- e.g. '2.0.0.Alpha1' -->
 	<property name="bv.version.qualifier" value="" /><!-- e.g. ' (Early Draft 1)' -->
 	<property name="bv.revdate" value="${current.date}" /> <!-- Replace with fixed date when releasing -->
-	<property name="license" value="license-evaluation" />
+	<property name="license" value="license" />
 	<property name="asciidoctor.version" value="1.5.3" />
 	<property name="maven-dependency-plugin.version" value="2.10" />
 	<property name="pdf.name" value="bean-validation-specification.pdf"/>

--- a/sources/license-evaluation.asciidoc
+++ b/sources/license-evaluation.asciidoc
@@ -40,7 +40,7 @@ Other than this limited license, you acquire no right, para or interest in or to
 
 TRADEMARKS
 
-No right, para, or interest in or to any trademarks, service marks, or trade names of Red Hat Inc. or Red Hat's licensors is granted hereunder. Java and Java-related logos, marks and names are trademarks or registered trademarks of Sun Microsystems, Inc. in the U.S. and other countries.
+No right, para, or interest in or to any trademarks, service marks, or trade names of Red Hat Inc. or Red Hat's licensors is granted hereunder. Java and Java-related logos, marks and names are trademarks or registered trademarks of Oracle and/or its affiliates in the U.S. and other countries.
 
 DISCLAIMER OF WARRANTIES
 


### PR DESCRIPTION
@gunnarmorling I also switched back to the Apache License. As I understood it, the snapshots are covered by the AL and the official releases by the evaluation license?

Just cherry-pick the first commit if I'm wrong.

(Btw, I added `and/or its affiliates` to conform with the Oracle trademarks guidelines)