### PR TITLE
BVAL-577 Proof-read "3.3. Constraint composition" on "composing" vs. "composed"

### DIFF
--- a/sources/constraint-definition.asciidoc
+++ b/sources/constraint-definition.asciidoc
@@ -436,7 +436,7 @@ If left undefined, the default value for [methodname]`@OverridesAttribute.name` 
 
 [NOTE]
 ====
-[tck-testable]#A composing constraint can itself be a composed constraint. In this case, attribute values are overridden recursively according to the described rules.# Note however, that a forwarding rule (as defined by [classname]`@OverridesAttribute`) is only applied to the direct composing constraints.
+[tck-testable]#A composed constraint can itself be a composing constraint. In this case, attribute values are overridden recursively according to the described rules.# Note however, that a forwarding rule (as defined by [classname]`@OverridesAttribute`) is only applied to the direct composing constraints.
 ====
 
 Using <<example-composing-overridden>>,
@@ -463,11 +463,11 @@ include::{spec-examples-source-dir}org/beanvalidation/specexamples/constraintdef
 [tck-testable]#If a constraint is used more than once as a composing constraint, the multi value constraints model as described in <<constraintsdefinitionimplementation-multipleconstraints>> is used.#
 
 To select a specific composing constraint, [methodname]`OverridesAttribute.constraintIndex` is used.
-[tck-testable]#If the composing constraints are directly given on the composing constraint, `constraintIndex` refers to the left-to-right order of the constraints of this type in which they are given on the composing constraint.#
+[tck-testable]#If the composing constraints are directly given on the composed constraint, `constraintIndex` refers to the left-to-right order of the constraints of this type in which they are given on the composed constraint.#
 [tck-testable]#If the composing constraints are specified using their corresponding `List` annotation, `constraintIndex` refers to the index within the `value` array.#
 [tck-testable]
 --
-A composing constraint must not be given directly on the composing constraint and using the corresponding `List` annotation at the same time.
+A composing constraint must not be given directly on the composed constraint and using the corresponding `List` annotation at the same time.
 A `ConstraintDeclarationException` will be raised in this case.
 --
 


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVAL-577