### PR TITLE
BVAL-578 Make the assertion related to NoProviderFoundException not testable

### DIFF
--- a/sources/exception.asciidoc
+++ b/sources/exception.asciidoc
@@ -139,6 +139,6 @@ These exception cases can be determined at compile time by a tool such as an ann
 
 === No Bean Validation Provider detected: `NoProviderFoundException`
 
-[tck-testable]#When trying to bootstrap Bean Validation via `Validation.buildDefaultValidatorFactory()` or `Validation.byDefaultProvider().configure()` and no Bean Validation provider could be found, a `NoProviderFoundException` is raised.#
+[tck-not-testable]#When trying to bootstrap Bean Validation via `Validation.buildDefaultValidatorFactory()` or `Validation.byDefaultProvider().configure()` and no Bean Validation provider could be found, a `NoProviderFoundException` is raised.#
 
 `NoProviderFoundException` is a subclass of `ValidationException`.


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVAL-578