### PR TITLE
BVAL-526 Restart example numbering for each chapter

### DIFF
--- a/sources/appendix-jpa.asciidoc
+++ b/sources/appendix-jpa.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[appendix-jpa]]
 
 

--- a/sources/appendix-jpa.asciidoc
+++ b/sources/appendix-jpa.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[appendix-jpa]]
 
 

--- a/sources/appendix-standardresolvermessages.asciidoc
+++ b/sources/appendix-standardresolvermessages.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[standard-resolver-messages]]
 
 

--- a/sources/appendix-standardresolvermessages.asciidoc
+++ b/sources/appendix-standardresolvermessages.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[standard-resolver-messages]]
 
 

--- a/sources/appendix-value-extraction.asciidoc
+++ b/sources/appendix-value-extraction.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[appendix-value-extraction]]
 
 [appendix]
@@ -292,6 +293,8 @@ As an example, consider a generic type `Wrapper<T>` and a non-generic sub-type `
 
 Two defined sub-types of `javax.validation.Payload` can be used to control the target of validation in such cases via the constraint's `payload()` attribute:
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .`Payload` types for unwrapping control
 ====
 
@@ -308,6 +311,8 @@ include::{validation-api-source-dir}javax/validation/valueextraction/Unwrapping.
 ----
 
 Value extractor definitions can be marked with the `@UnwrapByDefault` annotation so that constraints are automatically applied to the wrapped value if a constraint is found for an element handled by that extractor:
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .`@UnwrapByDefault` annotation
 ====

--- a/sources/appendix-value-extraction.asciidoc
+++ b/sources/appendix-value-extraction.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[appendix-value-extraction]]
 
 [appendix]

--- a/sources/builtin-constraints.asciidoc
+++ b/sources/builtin-constraints.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[builtinconstraints]]
 
 == Built-in Constraint definitions
@@ -12,6 +13,8 @@ The specification defines a small set of built-in constraints. Their usage is en
 Built-in annotations are annotated with an empty [classname]`@Constraint` annotation to avoid any dependency between the specification API and a specific implementation. [tck-testable]#Each Bean Validation provider must recognize built-in constraint annotations as valid constraint definitions and provide compliant constraint implementations for each.# [tck-testable]#The built-in constraint validation implementation is having a lower priority than an XML mapping definition.# In other words [classname]`ConstraintValidator` implementations for built-in constraints can be overridden by using the XML mapping (see <<xml-mapping-constraintdefinition>>).
 
 All built-in constraints are in the [classname]`javax.validation.constraints` package. Here is the list of constraints and their declaration.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .[tck-testable]#@Null constraint#
 ====
@@ -23,6 +26,8 @@ include::{validation-api-source-dir}javax/validation/constraints/Null.java[lines
 
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .[tck-testable]#@NotNull constraint#
 ====
 
@@ -32,6 +37,8 @@ include::{validation-api-source-dir}javax/validation/constraints/NotNull.java[li
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .[tck-testable]#@AssertTrue constraint#
 ====
@@ -43,6 +50,8 @@ include::{validation-api-source-dir}javax/validation/constraints/AssertTrue.java
 
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .[tck-testable]#@AssertFalse constraint#
 ====
 
@@ -52,6 +61,8 @@ include::{validation-api-source-dir}javax/validation/constraints/AssertFalse.jav
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .[tck-testable]#@Min constraint#
 ====
@@ -63,6 +74,8 @@ include::{validation-api-source-dir}javax/validation/constraints/Min.java[lines=
 
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .[tck-testable]#@Max constraint#
 ====
 
@@ -72,6 +85,8 @@ include::{validation-api-source-dir}javax/validation/constraints/Max.java[lines=
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .[tck-testable]#@DecimalMin constraint#
 ====
@@ -83,6 +98,8 @@ include::{validation-api-source-dir}javax/validation/constraints/DecimalMin.java
 
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .[tck-testable]#@DecimalMax constraint#
 ====
 
@@ -92,6 +109,8 @@ include::{validation-api-source-dir}javax/validation/constraints/DecimalMax.java
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .[tck-testable]#@Size constraint#
 ====
@@ -103,6 +122,8 @@ include::{validation-api-source-dir}javax/validation/constraints/Size.java[lines
 
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .[tck-testable]#@Digits constraint#
 ====
 
@@ -112,6 +133,8 @@ include::{validation-api-source-dir}javax/validation/constraints/Digits.java[lin
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .[tck-testable]#@Past constraint#
 ====
@@ -123,6 +146,8 @@ include::{validation-api-source-dir}javax/validation/constraints/Past.java[lines
 
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .[tck-testable]#@Future constraint#
 ====
 
@@ -132,6 +157,8 @@ include::{validation-api-source-dir}javax/validation/constraints/Future.java[lin
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .[tck-testable]#@Pattern constraint#
 ====

--- a/sources/builtin-constraints.asciidoc
+++ b/sources/builtin-constraints.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[builtinconstraints]]
 
 == Built-in Constraint definitions

--- a/sources/changelog.asciidoc
+++ b/sources/changelog.asciidoc
@@ -2,12 +2,15 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[changelog]]
 
 
 [appendix]
 == Changelog
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Changelog
 ====

--- a/sources/changelog.asciidoc
+++ b/sources/changelog.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[changelog]]
 
 

--- a/sources/constraint-declaration-validation.asciidoc
+++ b/sources/constraint-declaration-validation.asciidoc
@@ -2,6 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+:chapNum: {counter:chapter}
+:index: 0
 
 [[constraintdeclarationvalidationprocess]]
 
@@ -75,6 +77,7 @@ When using field access strategy, the Bean Validation provider accesses the inst
 
 In addition to supporting instance validation, validation of graphs of objects is also supported. The result of a graph validation is returned as a unified set of constraint violations. [classname]`@Valid` is used to express validation traversal of an association.
 
+[caption="Example {chapter}.{counter:index:1}: "]
 .[classname]`@Valid` annotation
 
 ====
@@ -142,6 +145,8 @@ A group defines a subset of constraints. Instead of validating all constraints f
 
 [tck-testable]#Groups are represented by interfaces.#
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Definition of groups
 ====
 
@@ -164,6 +169,7 @@ public interface BuyInOneClick {
 [tck-testable]#A constraint can belong to one or more groups.#
 
 [[example-assigngrouptoconstraints]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Assign groups to constraints
 ====
@@ -216,6 +222,7 @@ public interface Default {
 
 In some situations, a group is a superset of one or more groups. This can be described by Bean Validation. [tck-testable]#A group may inherit one or more groups by using interface inheritance.#
 
+[caption="Example {chapter}.{counter:index}: "]
 .Groups can inherit other groups
 ====
 
@@ -233,6 +240,7 @@ public interface BuyInOneClick extends Default, Billable {}
 
 In the following example:
 
+[caption="Example {chapter}.{counter:index}: "]
 .Use of a inherited group
 ====
 
@@ -300,6 +308,7 @@ include::{validation-api-source-dir}javax/validation/GroupSequence.java[lines=18
 Here is a usage example:
 
 [[example-groupsequence]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Make use of group sequence
 ====
@@ -347,6 +356,7 @@ In <<example-groupsequence>>, when the [classname]`Address.Complete` group is va
 In <<example-groupsequence>>, validating the [classname]`Default` group does not validate [classname]`HighLevelCoherence` constraints. To ensure a complete validation, a user must use the [classname]`Complete` group. This breaks some of the encapsulation you could expect. You can work around this by redefining what the [classname]`Default` group means for a given class. [tck-testable]#To redefine [classname]`Default` for a class, place a [classname]`@GroupSequence` annotation on the class; this sequence expresses the sequence of groups that does substitute [classname]`Default` for this class.#
 
 [[example-overridedefaultgroup]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Redefining Default group for Address
 ====
@@ -385,6 +395,8 @@ Since sequences cannot have circular dependencies, using [classname]`Default` in
 ==== Implicit grouping
 
 It is possible to implicitly group several constraints in the same group without explicitly listing such a group in the constraint declaration. [tck-testable]#Every constraint hosted on an interface [classname]`Z` and part of the [classname]`Default` group (implicitly or explicitly) belongs to the group [classname]`Z`.# This is useful to validate the partial state of an object based on a role represented by an interface.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Example of interface / group hosting constraints
 ====
@@ -447,6 +459,8 @@ When an [classname]`Order` object is validated on the [classname]`Auditable` gro
 
 When performing cascading validation, it is possible to use a different group than the one originally requested using the group conversion feature. Group conversions are declared by using the [classname]`@ConvertGroup` annotation.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .@ConvertGroup annotation
 ====
 
@@ -490,8 +504,6 @@ Group circularity in a group conversion are not problematic because:
 * only one rule is applied for a given cascade (rules are not applied recursively)
 * validation cascading is stopped when the same instance / property is validated with the same group in a given path (existing rule)
 
-
-
 ====
 
 [tck-testable]#[classname]`@ConvertGroup` and [classname]`@ConvertGroup.List` can only be placed where [classname]`@Valid` is present to ensure proper respect of the Liskov substitution principle:# if rules were to be defined on an overriding method of a method marked as cascading validation, the rules could end up altering the list of constraints validated by the super type and thus violating the Liskov substitution principle.
@@ -505,6 +517,8 @@ Group conversion is quite useful to facilitate object graph reuse without spread
 ===== Group conversion examples
 
 In this example we will reuse the [classname]`Address` group split and match it to the [classname]`User` group split.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Example of group conversion
 ====
@@ -544,6 +558,8 @@ public class User {
 When validating an instance of [classname]`User` with the [classname]`Default` group, the associated addresses are validated with the [classname]`BasicPostal` group. When validating an instance of [classname]`User` with the [classname]`Complete` group, the associated addresses are validated with the [classname]`FullPostal` group.
 
 The following example shows an illegal declaration of a group conversion rule on a method's return value:
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Example of an illegal group conversion
 ====
@@ -708,6 +724,8 @@ Getters are not considered constrained methods by default (see <<integration-gen
 
 [tck-testable]#Parameter constraints are declared by putting constraint annotations on method or constructor parameters.#
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Declaring parameter constraints
 ====
 
@@ -750,6 +768,8 @@ In order to use constraint annotations for method or constructor parameters, the
 ===== Cross-parameter constraints
 
 Cross-parameter constraints allow to express constraints based on the value of several method parameters, similar to class-level constraints which are based on several properties of a given class. [tck-testable]#Cross-parameter constraints are declared by putting cross-parameter constraint annotations on methods or constructors# as shown in the following example.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Declaring cross-parameter constraints
 ====
@@ -848,6 +868,8 @@ Bean Validation providers and integrators are free to provide additional impleme
 
 Some constraints can target both the return value and the array of parameters of an executable. [tck-testable]#They are known to be both generic and cross-parameter constraints. When using such constraint on an executable to target the return value, one must set [methodname]`validationAppliesTo` in case there is an ambiguity.# The set of ambiguities is described in <<constraintsdefinitionimplementation-constraintdefinition-validationappliesto>>. Even without ambiguity, it is recommended to explicitly set [methodname]`validationAppliesTo` to `ConstraintTarget.RETURN_VALUE` as it improves readability.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Declaring return value constraints
 ====
 
@@ -898,6 +920,7 @@ Like parameter constraints, these return value constraints are not per-se valida
 * [tck-testable]#The validation is recursive; that is, if validated parameter or return value objects have references marked with [classname]`@Valid` themselves, these references will also be validated#
 * [tck-not-testable]#Bean Validation providers must guarantee the prevention of infinite loops during cascaded validation#
 
+[caption="Example {chapter}.{counter:index}: "]
 
 .Marking parameters and return values for cascaded validation
 ====
@@ -966,6 +989,8 @@ Therefore the following rules with respect to the definition of method level con
 
 This sections provides some examples of illegal constraint definitions which violate the rules stated above in one way or another.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Illegally declared parameter constraints on interface implementation
 ====
 
@@ -992,6 +1017,8 @@ public class SimpleOrderService implements OrderService {
 ====
 
 The constraints in [classname]`SimpleOrderService` are illegal, as they strengthen the preconditions of the [methodname]`placeOrder()` method as constituted by the interface [classname]`OrderService`.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Illegally declared parameter constraints on sub class
 ====
@@ -1023,6 +1050,7 @@ public class SimpleOrderService extends OrderService {
 The constraints in [classname]`SimpleOrderService` are illegal, as they strengthen the preconditions of the [methodname]`placeOrder()` method as constituted by the super class [classname]`OrderService`.
 
 [[illegal_constraints_in_parallel_types]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Illegally declared parameter constraints on parallel types
 ====
@@ -1055,6 +1083,8 @@ public class SimpleOrderService implements OrderService, OrderPlacementService {
 ====
 
 Here the class [classname]`SimpleOrderService` implements the interfaces [classname]`OrderService` and [classname]`OrderPlacementService`, which themselves are unrelated to each other but both define a method [methodname]`placeOrder()` with an identical signature. This hierarchy is illegal with respect to the parameter constraints as a client of [classname]`SimpleOrderService` would have to fulfill the constraints defined on the interface [classname]`OrderPlacementService` even if the client only expects [classname]`OrderService`.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Correctly declared return value constraints on sub class
 ====
@@ -1131,6 +1161,7 @@ This object graph navigation can lead to multiple validations of the same constr
 ====
 
 [[example-oglimit]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Object graph limits
 ====
@@ -1183,6 +1214,8 @@ The [classname]`ConstraintViolation` objects are built when a failing constraint
 
 [tck-testable]#[classname]`@Valid` is an orthogonal concept to the notion of group. If two groups are in sequence, the first group must pass for all associated objects before the second group is evaluated.# Note however that the [classname]`Default` group sequence overriding is local to the class it is defined on and is not propagated to the associated objects. The following example illustrates this:
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Class Driver with redefined default group
 ====
 
@@ -1205,6 +1238,8 @@ public class Driver {
 
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Class Car with redefined default group
 ====
 
@@ -1224,6 +1259,8 @@ public class Car {
 
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Defining a group sequence
 ====
 
@@ -1235,6 +1272,8 @@ public interface SequencedGroups {
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Group sequence overriding is not propagated to associated objects
 ====
@@ -1405,6 +1444,7 @@ The traversable resolver used by default by a Bean Validation provider behaves a
 An example implementation of such a resolver is shown in <<constraintdeclarationvalidationprocess-validationroutine-traversable-jparesolver>>.
 
 [[constraintdeclarationvalidationprocess-validationroutine-traversable-jparesolver]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Java Persistence aware TraversableResolver
 ====
@@ -1445,6 +1485,7 @@ See <<bootstrapping>> to learn how to pass a custom [classname]`TraversableResol
 The following example assumes the object graph defined in <<example-ognav-definitions>> and assumes the validation operation is applied on an address object.
 
 [[example-ognav-definitions]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Definitions used in the example
 ====
@@ -1559,6 +1600,7 @@ When the Bean Validation provider is about to cascade validation on `country` ([
 The following example shows invocations of the [classname]`TraversableResolver` as to be performed by the Bean Validation provider during method validation. The example is based on the object graph defined in <<example-ognav-definitions>> and the [classname]`AddressService` class shown in <<example-ognav-definitions-methodvalidation>>. It assumes that a call of [methodname]`persistAddress()` is subject to method parameter validation.
 
 [[example-ognav-definitions-methodvalidation]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Examplary class [classname]`AddressService`
 ====
@@ -1625,6 +1667,7 @@ While the Java compiler itself cannot determine if a constraint declaration will
 Let's see a couple of declarations and their respective [classname]`ConstraintValidator` resolution. Assuming the definitions shown in <<example-constraintvalidator-resolution>>:
 
 [[example-constraintvalidator-resolution]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .ConstraintValidator and type resolution
 ====
@@ -1691,6 +1734,8 @@ The resolutions shown in <<table-constraintvalidator-resolution>> occur.
 
 The first example demonstrates how beans, fields and getters are annotated to express some constraints.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Place constraint declarations on the element to validate
 ====
 
@@ -1753,6 +1798,8 @@ During the validation routine execution on an [classname]`Address` object,
 * [classname]`@ZipCodeCoherenceChecker` is a constraint whose validation implementation's [methodname]`isValid` method receives the [classname]`Address` object.
 
 The second example demonstrates object graph validation.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Define object graph validation
 ====
@@ -1858,6 +1905,8 @@ include::{spec-examples-source-dir}org/beanvalidation/specexamples/constraintdec
 
 The third example demonstrates superclass, inheritance and composite constraints.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Use inheritance, constraints on superclasses and composite constraints
 ====
 
@@ -1956,6 +2005,8 @@ When validating [classname]`CommonGuest`, the following constraints are processe
 * [classname]`@NotNull` on [methodname]`customerId`, [classname]`@Password` on [methodname]`password`
 
 The fourth example demonstrates the influence of group sequence.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Use groups and group sequence to define constraint ordering
 ====

--- a/sources/constraint-declaration-validation.asciidoc
+++ b/sources/constraint-declaration-validation.asciidoc
@@ -4,7 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
-
+:tIndex: 0
 [[constraintdeclarationvalidationprocess]]
 
 == Constraint declaration and validation process
@@ -77,7 +77,7 @@ When using field access strategy, the Bean Validation provider accesses the inst
 
 In addition to supporting instance validation, validation of graphs of objects is also supported. The result of a graph validation is returned as a unified set of constraint violations. [classname]`@Valid` is used to express validation traversal of an association.
 
-[caption="Example {chapter}.{counter:index:1}: "]
+[caption="Example {chapter}.{counter:index}: "]
 .[classname]`@Valid` annotation
 
 ====
@@ -1700,6 +1700,7 @@ public interface SerializableCollection extends Serializable, Collection {
 The resolutions shown in <<table-constraintvalidator-resolution>> occur.
 
 [[table-constraintvalidator-resolution]]
+[caption="Table {chapter}.{counter:tIndex}: "]
 
 .Resolution of ConstraintValidator for various constraints declarations
 [options="header"]

--- a/sources/constraint-definition.asciidoc
+++ b/sources/constraint-definition.asciidoc
@@ -4,7 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
-
+:tIndex: 0
 [[constraintsdefinitionimplementation]]
 
 == Constraint Definition

--- a/sources/constraint-definition.asciidoc
+++ b/sources/constraint-definition.asciidoc
@@ -2,6 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+:chapNum: {counter:chapter}
+:index: 0
 
 [[constraintsdefinitionimplementation]]
 
@@ -139,7 +141,7 @@ Payloads are typically used by validation clients to associate some metadata inf
 One use case for payload shown in <<example-payload>> is to associate a severity to a constraint. This severity can be exploited by a presentation framework to adjust how a constraint failure is displayed.
 
 [[example-payload]]
-
+[caption="Example {chapter}.{counter:index}: "]
 .Use of payload to associate severity to a constraint
 ====
 
@@ -175,6 +177,7 @@ The `payload` information can be retrieved from error reports via the [classname
 
 [tck-testable]#The type of the `validationAppliesTo` parameter is [classname]`ConstraintTarget`. The default value must be [classname]`ConstraintTarget.IMPLICIT`.#
 
+[caption="Example {chapter}.{counter:index}: "]
 .validationAppliesTo and ConstraintTarget
 ====
 
@@ -207,6 +210,7 @@ The constraint annotation definitions may define additional elements to paramete
 ==== Examples
 
 [[example-definition-notnull]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Simple constraint definition
 ====
@@ -225,6 +229,7 @@ include::{spec-examples-source-dir}org/beanvalidation/specexamples/constraintdef
 <<example-definition-notnull>> marks a [classname]`String` as a well-formed order number. The constraint validator is implemented by [classname]`OrderNumberValidator`.
 
 [[example-definition-crossparameter]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Simple cross-parameter constraint definition
 ====
@@ -244,6 +249,7 @@ include::{spec-examples-source-dir}org/beanvalidation/specexamples/constraintdef
 <<example-definition-crossparameter>> shows a cross-parameter constraint which ensures that two date parameters of a method are in the correct order. The constraint validator is implemented by [classname]`DateParametersConsistentValidator`.
 
 [[example-definition-genericandcrossparameter]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Constraint that is both generic and cross parameter
 ====
@@ -273,6 +279,7 @@ public User createUser(String email, String password, String repeatPassword) { [
 <<example-definition-genericandcrossparameter>> shows a constraint that can be applied both on the annotated element and across parameters of a method or a constructor. Note in this case the presence of [methodname]`validationAppliesTo`.
 
 [[example-definition-length]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Constraint definition with default parameter
 ====
@@ -289,6 +296,7 @@ include::{spec-examples-source-dir}org/beanvalidation/specexamples/constraintdef
 <<example-definition-length>> ensures that a given frequency is within the scope of human ears. The constraint definition includes an optional parameter that may be specified when the constraint is applied.
 
 [[example-definition-mandatory]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Constraint definition with mandatory parameter
 ====
@@ -317,6 +325,7 @@ Each constraint annotation type should be meta-annotated with [classname]`java.l
 This marks the constraint annotation type as repeatable and lets users specify the constraint several times without explicitly using the [classname]`List` annotation.
 All built-in annotations follow this pattern.
 
+[caption="Example {chapter}.{counter:index}: "]
 .Multi-valued constraint definition
 ====
 [source, JAVA, indent=0]
@@ -325,6 +334,7 @@ include::{spec-examples-source-dir}org/beanvalidation/specexamples/constraintdef
 ----
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
 .Multi-valued constraint declaration
 ====
 [source, JAVA, indent=0]
@@ -336,6 +346,7 @@ include::{spec-examples-source-dir}org/beanvalidation/specexamples/constraintdef
 In this example, both constraints apply to the [methodname]`zipCode` field but with different groups and with different error messages.
 It is also possible to specify a constraint several times by explicitly using the [classname]`@List` annotation (though simply repeating the annotation is the preferred idiom as of Bean Validation 2.0 and Java 8):
 
+[caption="Example {chapter}.{counter:index}: "]
 .Multi-valued constraint declaration using explicit [classname]`@List` annotation
 ====
 [source, JAVA, indent=0]
@@ -360,6 +371,7 @@ Constraint composition is useful in several ways:
 
 Composition is done by annotating a constraint annotation with the composing constraint annotations.
 
+[caption="Example {chapter}.{counter:index}: "]
 .Composition is done by annotating the composed constraint
 ====
 
@@ -378,6 +390,7 @@ Annotating an element with [classname]`@FrenchZipCode` (the composed annotation)
 
 It is possible to ensure that composing annotations do not raise individual error reports. In this scenario, if one or more composing annotations are invalid, the main constraint is automatically considered invalid and the corresponding error report is generated. To mark a constraint as raising a single constraint error report if either the composed or one of the composing constraints fail, use the [classname]`@ReportAsSingleViolation` annotation.
 
+[caption="Example {chapter}.{counter:index}: "]
 .If any of the composing constraints fail, the error report corresponding to [classname]`@FrenchZipCode` is raised and none other.
 ====
 
@@ -399,6 +412,7 @@ include::{validation-api-source-dir}javax/validation/ReportAsSingleViolation.jav
 
 [tck-testable]#Composing annotations can define the value of `message` and custom attributes (excluding [methodname]`groups`, [methodname]`payload` and [methodname]`validationAppliesTo`) but these are fixed in the composed constraint definition.#
 
+[caption="Example {chapter}.{counter:index}: "]
 .Composing annotations can use attributes. They are fixed for a given main annotation. All [classname]`@FrenchZipCode` constraints have a [classname]`@Size` restricted to 5.
 ====
 
@@ -417,6 +431,7 @@ Such an attribute is annotated with one or more `@OverridesAttribute` annotation
 --
 
 [[example-composing-overridden]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Attributes from composing annotations can be overridden by attributes from the composed annotation
 ====
@@ -473,6 +488,7 @@ A `ConstraintDeclarationException` will be raised in this case.
 
 [tck-testable]#If `index` is undefined, the single constraint declaration is targeted.#
 
+[caption="Example {chapter}.{counter:index}: "]
 .Use of constraintIndex in @OverridesAttribute
 ====
 
@@ -539,6 +555,7 @@ This restriction is not a theoretical limitation and a future version of the spe
 
 [tck-testable]#By default, a [classname]`ConstraintValidator` targets the (returned) element annotated by the constraint. You can make a [classname]`ConstraintValidator` target the array of parameters of a method or constructor (aka cross-parameter) by annotating the validator implementation with [classname]`@SupportedValidationTarget`.#
 
+[caption="Example {chapter}.{counter:index}: "]
 .@SupportedValidationTarget annotation and ValidationTarget enum
 ====
 
@@ -602,6 +619,7 @@ public enum ValidationTarget {
 
 [tck-testable]#If a [classname]`ConstraintValidator` targets array of parameters (cross-parameter), [classname]`T` must resolve to [classname]`Object[]` (or [classname]`Object`) in order to have the array of parameter values passed to the [methodname]`isValid()` method. A [classname]`ConstraintDefinitionException` is raised otherwise.#
 
+[caption="Example {chapter}.{counter:index}: "]
 .Example of cross parameter ConstraintValidator
 ====
 
@@ -627,6 +645,7 @@ public class ScriptAssertValidator implements ConstraintValidator<ScriptAssert,O
 
 [[example-constraintsdefinitionimplementation-validationimplementation-validdef]]
 
+[caption="Example {chapter}.{counter:index}: "]
 .Valid ConstraintValidator definitions
 ====
 
@@ -666,6 +685,7 @@ public class ELScriptValidator implements ConstraintValidator<ELScript, Object> 
 And some invalid definitions in <<example-constraintsdefinitionimplementation-validationimplementation-invaliddef>>.
 
 [[example-constraintsdefinitionimplementation-validationimplementation-invaliddef]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Invalid ConstraintValidator definitions
 ====
@@ -731,6 +751,7 @@ This object is built from the default constraint message template as defined by 
 <<example-constraintsdefinitionimplementation-validationimplementation-errorbuilder>> shows a few examples.
 
 [[example-constraintsdefinitionimplementation-validationimplementation-errorbuilder]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Using the fluent API to build custom constraint violations
 ====
@@ -839,6 +860,7 @@ This can be useful for testing, for applying the time zone of the currently logg
 
 ==== Examples
 
+[caption="Example {chapter}.{counter:index}: "]
 .ConstraintValidator implementation
 ====
 
@@ -880,6 +902,7 @@ This [classname]`ConstraintValidator` checks that a text is within the accepted 
 
 The following listing shows a validator implementing the validation logic for a cross-parameter constraint.
 
+[caption="Example {chapter}.{counter:index}: "]
 .Cross-parameter validator implementation
 ====
 
@@ -919,6 +942,7 @@ public class DateParametersConsistentValidator implements<DateParametersConsiste
 
 The following listing shows a validator implementing the validation logic for a constraint that is both generic and cross-parameter.
 
+[caption="Example {chapter}.{counter:index}: "]
 .Generic and cross-parameter validator implementation
 ====
 
@@ -945,6 +969,7 @@ public class ELScriptValidator implements<ELScript, Object> {
 
 The next example shows how to use [classname]`ConstraintValidatorContext`.
 
+[caption="Example {chapter}.{counter:index}: "]
 .Use of ConstraintValidatorContext
 ====
 
@@ -1004,6 +1029,7 @@ The default error message is disabled and replaced by a specific error message d
 
 The following example shows how to obtain the current date and time via the `ClockProvider` when validating a temporal constraint such as `@Past`:
 
+[caption="Example {chapter}.{counter:index}: "]
 .Validation of a temporal constraint
 ====
 
@@ -1027,6 +1053,7 @@ The lifecycle of [classname]`ConstraintValidator` instances is fully dependent o
 [classname]`ConstraintValidator` instances created by the [classname]`ValidatorFactory` -level [classname]`ConstraintValidatorFactory` can be released when the [classname]`ValidatorFactory` is being closed.
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
 .ConstraintValidatorFactory interface
 ====
 

--- a/sources/constraint-metadata.asciidoc
+++ b/sources/constraint-metadata.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[constraintmetadata]]
 
 == Constraint metadata request APIs
@@ -14,6 +15,8 @@ The Bean Validation specification provides a way to query the constraint reposit
 The main API to access all metadata related to a given object is [classname]`Validator` (see <<bootstrapping>> for more information on how to retrieve a [classname]`Validator` instance).
 
 A [classname]`Validator` instance hosts the method to access to the metadata repository for a given class. It is recommended to leave the caching of [classname]`Validator` instances to the [classname]`ValidatorFactory`. [classname]`Validator` implementations are thread-safe.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Validator interface (metadata request API)
 ====
@@ -61,6 +64,8 @@ All descriptor types accessible via [methodname]`getConstraintsForClass()` and i
 === ElementDescriptor
 
 [classname]`ElementDescriptor` is the root interface describing elements hosting constraints. It is used to describe the list of constraints for a given element (whether it be a class, property, method etc.).
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .ElementDescriptor interface
 ====
@@ -225,6 +230,8 @@ public enum Scope {
 
 Here is an example restricting the list of constraints on getters, matching the default group and declared physically on the `name` getter of [classname]`Customer` (and not any of the getters on the super classes).
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Using the fluent API to restrict matching constraints
 ====
 
@@ -267,6 +274,8 @@ assert 2 == constraints.size();
 ====
 
 The following example shows how the fluent API is used to retrieve parameter, cross-parameter and return value constraints, taking into account locally declared constraints as well as constraints declared in the inheritance hierarchy.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Using the fluent API to select method and constructor constraints
 ====
@@ -345,6 +354,8 @@ assert 1 == constructorDescriptor.getParameterDescriptors()
 === BeanDescriptor
 
 The [classname]`BeanDescriptor` interface describes a constrained Java Bean. This interface is returned by [methodname]`Validator.getConstraintsForClass(Class<?>)`.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .BeanDescriptor interface
 ====
@@ -473,6 +484,8 @@ public interface BeanDescriptor extends ElementDescriptor {
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .MethodType
 ====

--- a/sources/constraint-metadata.asciidoc
+++ b/sources/constraint-metadata.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[constraintmetadata]]
 
 == Constraint metadata request APIs

--- a/sources/exception.asciidoc
+++ b/sources/exception.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[exception]]
 
 == Exception model
@@ -38,6 +39,8 @@ If a constraint definition or constraint declaration is invalid for a given clas
 Some frameworks or applications need to convey the result of a validation by raising an exception if the validation returns constraint violations.
 
 Bean Validation provides a reference exception for such cases. Frameworks and applications are encouraged to use [classname]`ConstraintViolationException` as opposed to a custom exception to increase consistency of the Java platform. The exception can be raised directly or wrapped into the framework or application specific parent exception.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .ConstraintViolationException
 ====

--- a/sources/exception.asciidoc
+++ b/sources/exception.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[exception]]
 
 == Exception model

--- a/sources/index.asciidoc
+++ b/sources/index.asciidoc
@@ -14,6 +14,8 @@ Gunnar Morling
 :sectnumlevels: 4
 :docinfo:
 :docinfodir: ../docinfo
+:tIndex: {counter:tIndex:0}
+:index: {counter:index:0}
 
 [preface]
 include::sources/{license}.asciidoc[]

--- a/sources/integration.asciidoc
+++ b/sources/integration.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[integration]]
 
 == Integration

--- a/sources/integration.asciidoc
+++ b/sources/integration.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[integration]]
 
 == Integration
@@ -78,6 +79,7 @@ The following executable types are available:
 [tck-not-testable]#Mixing `IMPLICIT` and other executable types is illegal.#
 
 [[example-validateonexecution]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .@ValidateOnExecution annotation
 ====
@@ -97,6 +99,8 @@ include::{validation-api-source-dir}javax/validation/executable/ExecutableType.j
 [tck-not-testable]#If a sub type overrides/implements a method originally defined in several parallel types of the hierarchy (e.g. two interfaces not extending each other, or a class and an interface not implemented by said class), [classname]`@ValidateOnExecution` cannot be placed in the parallel types of the hierarchy.# This is to avoid an unexpected altering of the post conditions to be guaranteed to the caller.
 
 [tck-testable]#You can globally disable executable validation by using [code]`<executable-validation enabled="false"/>`, in this case, [code]`<default-validated-executable-types/>` and [classname]`@ValidateOnExecution` are ignored.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .validation.xml disabling executable validation
 ====
@@ -137,6 +141,8 @@ The proper selection of the validated executables is the responsibility of the i
 ===== Examples
 
 The following example shows some of the way you can refine executable validation with [classname]`@ValidateOnExecution`.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Method validation configurations
 ====

--- a/sources/introduction.asciidoc
+++ b/sources/introduction.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[introduction]]
 
 == Introduction

--- a/sources/introduction.asciidoc
+++ b/sources/introduction.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[introduction]]
 
 == Introduction

--- a/sources/terminology.asciidoc
+++ b/sources/terminology.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[terminology]]
 
 

--- a/sources/terminology.asciidoc
+++ b/sources/terminology.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[terminology]]
 
 

--- a/sources/validation-api.asciidoc
+++ b/sources/validation-api.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[validationapi]]
 
 == Validation APIs
@@ -990,6 +991,7 @@ public class Library {
 Assuming a [classname]`Book` instance gets validated, the property paths to the different constraints would be as described in <<table-propertypath>>:
 
 [[table-propertypath]]
+[caption="Table {chapter}.{counter:tIndex}: "]
 
 .propertyPath examples
 [options="header"]
@@ -1026,6 +1028,7 @@ PropertyNode(name=rating,inIterable=false, index=null, key=null, kind=ElementKin
 Assuming the constructor and methods of the [classname]`Library` class are subject to method constraint validation, the following property paths would exist for the different constraints:
 
 [[table-method-level-propertypath]]
+[caption="Table {chapter}.{counter:tIndex}: "]
 
 .Property path examples for constrained methods or constructors
 [options="header"]
@@ -1647,6 +1650,7 @@ myapp.creditcard.error=credit card number not valid
 ----
 
 [[table-messageinterpolation]]
+[caption="Table {chapter}.{counter:tIndex}: "]
 
 .message interpolation
 |===============

--- a/sources/validation-api.asciidoc
+++ b/sources/validation-api.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[validationapi]]
 
 == Validation APIs
@@ -16,6 +17,8 @@ The default package for the Bean Validation APIs is [classname]`javax.validation
 The main Bean Validation API is the [classname]`javax.validation.Validator` interface.
 
 A [classname]`Validator` instance is able to validate instances of beans and their associated objects if any. It is recommended to leave the caching of [classname]`Validator` instances to the [classname]`ValidatorFactory`. [tck-not-testable]#[classname]`Validator` implementations must be thread-safe.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Validator interface
 ====
@@ -34,6 +37,8 @@ The methods [methodname]`validate()`, [methodname]`validateProperty()` and [meth
 [methodname]`getConstraintsForClass()` returns constraint-related metadata for given types and is described in detail in <<constraintmetadata>>.
 
 [methodname]`unwrap()` is provided as a way to access objects of a given type specific to a Bean Validation provider typically as a complement to the [classname]`Validator` contract. Using this method makes your code non portable.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Using unwrap to access a provider specific contract
 ====
@@ -157,6 +162,8 @@ validator.validateValue("city", "Paris").size() == 0
 ==== Methods for validating method and constructor constraints
 
 The methods for the validation of parameters and return values of methods and constructors can be found on the interface [classname]`javax.validation.executable.ExecutableValidator`.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .ExecutableValidator interface
 ====
@@ -687,6 +694,8 @@ The [methodname]`getLeafBean()` method returns the following object:
 
 [methodname]`unwrap()` is provided as a way to access objects of a given type specific to a Bean Validation provider typically as a complement to the [classname]`ConstraintViolation` contract. Using this method makes your code non portable.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Path, Node and ElementKind interfaces
 ====
 
@@ -784,6 +793,8 @@ Nodes are of the following possible types:
 
 
 It is possible to narrow a node instance to its precise type and extract node specific information by the use of [methodname]`Node.getKind()` and [methodname]`Node.as(Class<? extends Node>)`. [tck-testable]#In particular, [classname]`MethodNode` and [classname]`ConstructorNode` host [methodname]`getParameterTypes()` which return the method or constructor parameter list.# [tck-testable]#Likewise [classname]`ParameterNode` hosts [methodname]`getParameterIndex()` which returns the parameter index in the method or constructor parameter list.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Narrow a node to its specific type
 ====
@@ -903,6 +914,8 @@ From [methodname]`getRootBean()`, [methodname]`getPropertyPath()`, [methodname]`
 ====
 
 Let there be the following object definitions:
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Object model definition for examples
 ====
@@ -1111,6 +1124,8 @@ Set<ConstraintViolation> constraintViolations = validator.validate(book);
 [classname]`ConstraintViolations` is a set of size 2. One of the entries represents the failure of `@NotEmpty` (or more precisely [classname]`@Size(min=1)` a composing constraint of [classname]`@NotEmpty`) on the `title` property.
 
 The [classname]`ConstraintViolation` object for this failure passes the following assertions:
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Test assertions on ContraintViolation
 ====
@@ -1442,6 +1457,8 @@ A message interpolator is responsible for transforming the so called message des
 
 Below are two examples using message parameters and expressions. The second is evaluated using Expression Language as defined in <<message-expressions>>.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Message using parameters
 ====
 
@@ -1451,6 +1468,8 @@ Value must be between {min} and {max}
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Message using expressions
 ====
@@ -1644,6 +1663,8 @@ Here is an approach to specify the [classname]`Locale` value to choose on a give
 
 [[validationapi-message-examples-specificlocale]]
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Use MessageInterpolator to use a specific Locale value
 ====
 
@@ -1695,6 +1716,7 @@ Validator validator = validatorFactory.usingContext()
 Most of the time, however, the relevant [classname]`Locale` will be provided by your application framework transparently. This framework will implement its own version of [classname]`MessageInterpolator` and pass it during the [classname]`ValidatorFactory` configuration. The application will not have to set the [classname]`Locale` itself. This example shows how a container framework would implement [classname]`MessageInterpolator` to provide a user specific default locale.
 
 [[validationapi-message-examples-jsflocale]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Contextual container possible [classname]`MessageInterpolator` implementation
 ====
@@ -1765,6 +1787,8 @@ Integrators are encouraged to use Bean Validation's metadata API to find whether
 
 Here is an example of what such metadata usage would be:
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Using metadata API to figure out if method interception is required
 ====
 
@@ -1814,6 +1838,8 @@ public boolean requiresReturnValueValidation(Class<?> type, Method method) {
 ----
 
 ====
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Using metadata API to figure out if constructor interception is required
 ====
@@ -1924,6 +1950,8 @@ Let's first see the API in action through some examples before diving into the c
 
 The most simple approach is to initialize the default Bean Validation provider or the one defined in the XML configuration file. The [classname]`ValidatorFactory` is then ready to provide [classname]`Validator` instances.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Simple Bean Validation bootstrap sequence
 ====
 
@@ -1943,6 +1971,8 @@ factory.close();
 [tck-not-testable]#The [classname]`ValidatorFactory` object is thread-safe.# Building [classname]`Validator` instances is typically a cheap operation. Building a [classname]`ValidatorFactory` is typically more expensive. Make sure to check your Bean Validation implementation documentation for more accurate details.
 
 The second example shows how a container can customize some Bean Validator resource handling to match its own behavior.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Customize message resolution, traversable resolver, constraint validator factory, parameter name provider and clock provider implementation
 ====
@@ -1970,6 +2000,8 @@ factory.close();
 
 The third example shows how to bootstrap Bean Validation in an environment not following the traditional Java classloader strategies (such as tools or alternative service containers like OSGi). They can provide some alternative provider resolution strategy to discover Bean Validation providers.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Customize the Bean Validation provider resolution mechanism
 ====
 
@@ -1992,6 +2024,8 @@ factory.close();
 ====
 
 The next example shows how a client can choose a specific Bean Validation provider and configure provider specific properties programmatically in a type-safe way.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Use a specific provider and add specific configuration
 ====
@@ -2040,6 +2074,8 @@ public class ACMEProvider implements ValidationProvider<ACMEConfiguration> {
 
 The last example shows how a [classname]`Validator` can use a specific [classname]`MessageInterpolator` implementation.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Use a specific MessageInterpolator instance for a given Validator
 ====
 
@@ -2069,6 +2105,8 @@ We will now explore the various interfaces, their constraints and usage. We will
 
 [tck-not-testable]#[classname]`ValidatorFactory` implementations must be thread-safe.# [classname]`ValidatorFactory` implementations can cache [classname]`Validator` instances if needed.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .ValidatorFactory interface
 ====
 
@@ -2082,6 +2120,8 @@ include::{validation-api-source-dir}javax/validation/ValidatorFactory.java[lines
 A [classname]`ValidatorFactory` is provided by a [classname]`Configuration` object.
 
 [methodname]`unwrap()` is provided as a way to access objects of a given type specific to a Bean Validation provider typically as a complement to the [classname]`ValidatorFactory` contract. Using this method makes your code non portable.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Using unwrap to access a provider specific contract
 ====
@@ -2109,6 +2149,8 @@ acmeFactory.setSpecificConfiguration( [...] );
 
 [classname]`ValidatorContext` returned by [methodname]`usingContext()` can be used to customize the state in which the [classname]`Validator` must be initialized. This is used to customize the [classname]`MessageInterpolator`, the [classname]`TraversableResolver`, the [classname]`ParameterNameProvider`, the  [classname]`ClockProvider` or the [classname]`ConstraintValidatorFactory`.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .ValidatorContext interface
 ====
 
@@ -2120,6 +2162,8 @@ include::{validation-api-source-dir}javax/validation/ValidatorContext.java[lines
 ====
 
 [tck-testable]#The `MessageInterpolator`, the `TraversableResolver`, the `ConstraintValidatorFactory`, the `ParameterNameProvider` or the `ClockProvider` passed to the `ValidatorContext` are used instead of the ``ValidatorFactory``'s `MessageInterpolator`, `TraversableResolver`, `ConstraintValidatorFactory`, `ParameterNameProvider` or `ClockProvider` instances.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Use of ValidatorFactory
 ====
@@ -2173,6 +2217,8 @@ The responsibility of the [classname]`Configuration` is to collect configuration
 
 Clients call [methodname]`Configuration.buildValidatorFactory()` to retrieve the initialized [classname]`ValidatorFactory` instance. [tck-testable]#It is legal to invoke [methodname]`buildValidatorFactory()` several times, e.g. in order to retrieve several [classname]`ValidatorFactory` instances with a slightly different configuration (see <<using-configuration-several-times>>).#
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Configuration and BootstrapConfiguration interfaces
 ====
 
@@ -2193,6 +2239,7 @@ include::{validation-api-source-dir}javax/validation/BootstrapConfiguration.java
 To facilitate the use of provider specific configuration methods, [classname]`Configuration` uses generics: [classname]`Configuration<T extends Configuration<T>>` ; the generic return type [classname]`T` is returned by chaining methods. The provider specific sub interface must resolve the generic T as itself as shown in <<example-providerspecific-config>>.
 
 [[example-providerspecific-config]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Example of provider specific Configuration sub interface
 ====
@@ -2225,6 +2272,8 @@ A typical implementation of [classname]`Configuration` also implements [classnam
 ====
 
 [tck-not-testable]#Streams represented in the XML configuration and opened by the [classname]`Configuration` implementation must be closed by the [classname]`Configuration` implementation after the [classname]`ValidatorFactory` creation (or if an exception occurs).# Streams provided programmatically are the responsibility of the application.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .ConfigurationState interface
 ====
@@ -2263,6 +2312,8 @@ Other exception causes may occur.
 
 Here is an example of [classname]`Configuration` use.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Use Configuration
 ====
 
@@ -2280,6 +2331,7 @@ ValidatorFactory factory = configuration
 The following shows an example of setting up a [classname]`Configuration`, retrieving a validator factory from it, subsequently altering the configuration and then retrieving another factory:
 
 [[using-configuration-several-times]]
+[caption="Example {chapter}.{counter:index}: "]
 
 .Using Configuration to create several validator factories
 ====
@@ -2307,6 +2359,8 @@ Here, [varname]`factory1` is set up using a custom message interpolator, while [
 ===== ValidationProviderResolver
 
 [tck-testable]#[classname]`ValidationProviderResolver` returns the list of Bean Validation providers available at runtime and more specifically a [classname]`ValidationProvider` instance for each provider available in the context.# This service can be customized by implementing [classname]`ValidationProviderResolver`. [tck-not-testable]#Implementations must be thread-safe.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .ValidationProviderResolver
 ====
@@ -2359,6 +2413,7 @@ The default [classname]`ValidationProviderResolver` can be accessed via [classna
 * Provide a provider specific [classname]`Configuration` implementation. This [classname]`Configuration` will specifically build [classname]`ValidatorFactory` instances of the provider it comes from.
 * Build a [classname]`ValidatorFactory` object from the configuration provided by [classname]`ConfigurationState`.
 
+[caption="Example {chapter}.{counter:index}: "]
 
 .ValidationProvider
 ====
@@ -2424,6 +2479,8 @@ public interface ValidationProvider<T extends Configuration<T>> {
 
 ====
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .BootstrapState interface
 ====
 
@@ -2462,6 +2519,8 @@ public interface BootstrapState {
 [tck-testable]#A client can request a specific Bean Validation provider by using [classname]`<T extends Configuration<T>, U extends ValidationProvider<T>> Validation.byProvider(Class<U>)` or by defining the provider in the XML configuration file.# The key uniquely identifying a Bean Validation provider is the [classname]`ValidationProvider` implementation specific to this provider.
 
 A [classname]`ValidationProvider` implementation is linked (via its generic parameter) to a specific sub interface of [classname]`Configuration`. The Bean Validation bootstrap API makes use of this link to return the specific [classname]`Configuration` subinterface implementation in a type-safe way when a specific provider is requested. The sub interface does not have to add any new methods but is the natural holder for provider specific configuration methods.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Example of provider specific Configuration sub interface
 ====
@@ -2526,6 +2585,8 @@ The provider discovery mechanism uses the following algorithm:
 ==== Validation
 
 The [classname]`Validation` class is the entry point used to bootstrap Bean Validation providers. [tck-testable]#The first entry point, [methodname]`buildDefaultValidatorFactory()`, is considered to be the default [classname]`ValidatorFactory` and is equivalent to the [classname]`ValidatorFactory` returned by [code]`Validation.byDefaultProvider().configure().buildValidatorFactory()`.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Validation methods available
 ====
@@ -2672,6 +2733,8 @@ public class Validation {
 
 [tck-testable]#The second entry point lets the client provide a custom [classname]`ValidationProviderResolver` instance. This instance is passed to [classname]`GenericBootstrap`. [classname]`GenericBootstrap` builds a generic [classname]`Configuration` using the first [classname]`ValidationProvider` returned by [classname]`ValidationProviderResolution` and calling [code]`ValidationProvider.createGenericConfiguration(BootstrapState state)`.# [classname]`BootstrapState` holds the [classname]`ValidationProviderResolution` instance passed to [classname]`GenericBootstrap` and will be used by the [classname]`Configuration` instance when resolving the provider to use. Note that [code]`ValidationProvider.createGenericConfiguration` returns a [classname]`Configuration` object not bound to any particular provider.
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .GenericBootstrap interface
 ====
 
@@ -2685,6 +2748,8 @@ include::{validation-api-source-dir}javax/validation/bootstrap/GenericBootstrap.
 [tck-testable]#The last entry point lets the client define the specific Bean Validation provider requested as well as a custom [classname]`ValidationProviderResolver` implementation if needed. The entry point method, [methodname]`Validation.byProvider(Class<U> providerType)`, takes the provider specific [classname]`ValidationProvider` implementation type and returns a [classname]`ProviderSpecificBootstrap` object that guarantees to return an instance of the specific [classname]`Configuration` sub interface.# Thanks to the use of generics, the client API does not have to cast to the [classname]`Configuration` sub interface.
 
 A [classname]`ProviderSpecificBootstrap` object can optionally receive a [classname]`ValidationProviderResolver` instance.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .ProviderSpecificBootstrap interface
 ====
@@ -2780,6 +2845,8 @@ The bootstrap API is designed to allow complete portability amongst Bean Validat
 [tck-testable]#All these top level elements are optional.#
 
 [tck-testable]#If a public no-arg constructor is missing on any of the classes referenced by the relevant XML elements, a [classname]`ValidationException` is raised during the [methodname]`Configuration.buildValidatorFactory()` call.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Example of META-INF/validation.xml file
 ====

--- a/sources/whatsnew.asciidoc
+++ b/sources/whatsnew.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[whatsnew]]
 
 == What's new

--- a/sources/whatsnew.asciidoc
+++ b/sources/whatsnew.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[whatsnew]]
 
 == What's new

--- a/sources/xml-descriptor.asciidoc
+++ b/sources/xml-descriptor.asciidoc
@@ -2,7 +2,8 @@
 //
 // License: Apache License, Version 2.0
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
-
+:chapNum: {counter:chapter}
+:index: 0
 [[xml]]
 
 == XML deployment descriptor
@@ -35,6 +36,8 @@ The `ignore-annotations` setting is not inherited from nor by the class hierarch
 ====
 
 [tck-testable]#If the name of the class does refer to a class not present in the classpath, a [classname]`ValidationException` is raised.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Example of bean XML declaration
 ====
@@ -72,6 +75,7 @@ Class level annotations are described via the `class` element. [tck-testable]#If
 * [tck-testable]#Constraints declared in XML and constraints declared in annotations are added and form the list of class-level declared constraints.#
 * [tck-testable]#[classname]`@GroupSequence` is considered unless `group-sequence` element is explicitly used.#
 
+[caption="Example {chapter}.{counter:index}: "]
 
 .Example of class-level declaration
 ====
@@ -114,6 +118,8 @@ Field level annotations are described via the `field` element. The `name` attrib
 
 [tck-testable]#If the name of the field does not correspond to a field in the given bean a [classname]`ValidationException` is raised.#
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Field-level declaration
 ====
 
@@ -153,6 +159,8 @@ Property-level annotations are described via the `getter` element. [tck-testable
 * [tck-testable]#Group conversions declared in XML and via the [classname]`@ConvertGroup` annotation are added and form the list of applied conversions. Note that the rules for the declaration of group conversions as outlined in <<constraintdeclarationvalidationprocess-groupsequence-groupconversion>> apply, in particular it is not legal to declare several conversions for the same source group.#
 
 [tck-testable]#If the name of the property does not correspond to a property in the given bean a [classname]`ValidationException` is raised.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Property-level declaration
 ====
@@ -225,6 +233,8 @@ You must declare all parameters even if they are not reconfigured to ensure the 
 * [tck-testable]#Constraints declared in XML and constraints declared in annotations are added and form the list of declared parameter, cross-parameter or return value constraints respectively.#
 * [tck-testable]#[classname]`@Valid` is considered unless the `valid` element is explicitly used.# [tck-ignore]#Note that the only way to disable cascading on a constructor parameter or return value marked as [classname]`@Valid` is to use `ignore-annotations=true`. This does not apply to cross-parameter elements as cascading does not make sense in this situation.#
 * [tck-testable]#Group conversions declared in XML and via the [classname]`@ConvertGroup` annotation are added and form the list of applied conversions. Note that the rules for the declaration of group conversions as outlined in <<constraintdeclarationvalidationprocess-groupsequence-groupconversion>> apply, in particular it is not legal to declare several conversions for the same source group. This does not apply to cross-parameter elements as cascading does not make sense in this situation.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Constructor-level declaration
 ====
@@ -317,6 +327,8 @@ You must declare all parameters even if they are not reconfigured to ensure the 
 * [tck-testable]#[classname]`@Valid` is considered unless the `valid` element is explicitly used.# [tck-ignore]#Note that the only way to disable cascading on a method parameter or return value marked as [classname]`@Valid` is to use `ignore-annotations=true`. This does not apply to cross-parameter elements as cascading does not make sense in this situation.#
 * [tck-testable]#Group conversions declared in XML and via the [classname]`@ConvertGroup` annotation are added and form the list of applied conversions. Note that the rules for the declaration of group conversions as outlined in <<constraintdeclarationvalidationprocess-groupsequence-groupconversion>> apply, in particular it is not legal to declare several conversions for the same source group. This does not apply to cross-parameter elements as cascading does not make sense in this situation.#
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Method-level declaration
 ====
 
@@ -379,6 +391,8 @@ Other custom elements of an annotation are represented by `element`. [tck-testab
 [tck-testable]#If the element represents an array of annotations, one or more `annotation` elements are placed under `element`.#
 
 [tck-testable]#Elements with default values in the annotation definition do not have to be represented in XML: the default value will be used in this case.# [tck-testable]#If an XML constraint declaration is missing mandatory elements, or if it contains elements not part of the constraint definition, a [classname]`ValidationException` is raised.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Constraint declaration
 ====
@@ -513,6 +527,8 @@ Other custom elements of an annotation are represented by `element`. [tck-testab
 
 [tck-testable]#Source and target group of a conversion rule are given by specifying their fully-qualified names within the `from` and `to` attribute respectively. If the `default-package` element is configured for the mapping file, any unqualified class names will be resolved using the given default package.#
 
+[caption="Example {chapter}.{counter:index}: "]
+
 .Declaration of group conversions
 ====
 
@@ -576,6 +592,8 @@ A constraint definition (i.e. the annotation representing a constraint), cannot 
 [tck-testable]#A constraint definition is represented by a `constraint-definition` element.# The `annotation` attribute represents the constraint annotation being altered. The `validated-by` elements represent the (ordered) list of [classname]`ConstraintValidator` implementations associated to the constraint.
 
 [tck-testable]#If `include-existing-validator` is set to false, [classname]`ConstraintValidator` defined on the constraint annotation are ignored.# [tck-testable]#If set to true, the list of [classname]``ConstraintValidator``s described in XML are concatenated to the list of [classname]`ConstraintValidator` described on the annotation to form a new array of [classname]`ConstraintValidator` evaluated.# [tck-testable]#Annotation based [classname]`ConstraintValidator` come before XML based [classname]``ConstraintValidator``s in the array.# [tck-testable]#The new list is returned by [methodname]`ConstraintDescriptor.getConstraintValidatorClasses()`.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .Overriding constraint definitions
 ====
@@ -651,6 +669,8 @@ This section contains the XML schema used for constraint mapping descriptors.
 From Bean Validation revision 1.1 onwards, mapping authors must specify the used version of the schema within the `version` attribute of the `constraint-mappings` element. [tck-testable]#Implementations supporting Bean Validation 2.0 must properly parse mapping descriptors of Bean Validation 1.0, 1.1 and 2.0.# [tck-not-testable]#If the `version` attribute attribute is not given, schema version 1.0 is to be assumed by the Bean Validation provider.#
 
 [tck-testable]#In case an unknown version is given (e.g. if a mapping descriptor adhering to a future schema version is parsed by a Bean Validation 2.0 provider) a [classname]`ValidationException` is raised.#
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .XML schema for constraint mapping descriptors
 ====
@@ -928,6 +948,8 @@ From Bean Validation revision 1.1 onwards, mapping authors must specify the used
 === Configuration schema
 
 XML Configuration is set in [filename]`META-INF/validation.xml`. The file is optional. The XML schema followed by the configuration file is as followed.
+
+[caption="Example {chapter}.{counter:index}: "]
 
 .XML configuration XSD
 ====

--- a/sources/xml-descriptor.asciidoc
+++ b/sources/xml-descriptor.asciidoc
@@ -4,6 +4,7 @@
 // See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
 :chapNum: {counter:chapter}
 :index: 0
+:tIndex: 0
 [[xml]]
 
 == XML deployment descriptor


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/BVAL-526

Done it with some `[caption="...."]` and counters magic :)

Also I see that there's the same numbering for HV through all chapters (without restart), I'd say that the same change should be applied for HV documentation as well, WDYT?

As for how does it look with this change (without building the doc) - you can check a screen:

<img width="839" alt="bean_validation_specification" src="https://cloud.githubusercontent.com/assets/4004823/23817096/ec7e4b38-05f0-11e7-9b60-a30b2034e972.png">
