### PR TITLE
BVAL-528 Replace API listings by source includes

### DIFF
--- a/sources/appendix-value-extraction.asciidoc
+++ b/sources/appendix-value-extraction.asciidoc
@@ -57,25 +57,9 @@ class CustList extends List<@NotNull Customer> {
 
 Value retrieval for cascaded validation and validation of type argument constraints is done via the `ValueExtractor` API:
 
-[source,java]
+[source, JAVA, indent=0]
 ----
-package javax.validation.valueretrieval;
-
-public interface ValueExtractor<T> {
-
-	void extractValues(T originalValue, ValueReceiver receiver);
-
-	interface ValueReceiver {
-
-		void value(String nodeName, Object object);
-
-		void iterableValue(String nodeName, Object object);
-
-		void indexedValue(String nodeName, int i, Object object);
-
-		void keyedValue(String nodeName, Object key, Object object);
-	}
-}
+include::{validation-api-source-dir}javax/validation/valueextraction/ValueExtractor.java[lines=7..8;15..-1]
 ----
 
 An extractor is tied to one specific type parameter of the type from which it extracts values. The `@ExtractedValue` annotation is used to mark that type parameter.
@@ -106,22 +90,9 @@ That's desirable for pure "wrapper types" such as `Optional`.
 
 The `@ExtractedValue` annotation is used to denote the element extracted by a given value extractor:
 
-[source,java]
+[source, JAVA, indent=0]
 ----
-package javax.validation.valueextraction;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-/**
- * @author Gunnar Morling
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-public @interface ExtractedValue {
-}
+include::{validation-api-source-dir}javax/validation/valueextraction/ExtractedValue.java[lines=7..8;15..-1]
 ----
 
 The `@ExtractedValue` annotation must be specified exactly once for a value extractor type.

--- a/sources/constraint-declaration-validation.asciidoc
+++ b/sources/constraint-declaration-validation.asciidoc
@@ -78,23 +78,9 @@ In addition to supporting instance validation, validation of graphs of objects i
 .[classname]`@Valid` annotation
 
 ====
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-/**
- * Marks a property, method parameter or method return type for validation cascading.
- * <p/>
- * Constraints defined on the object and its properties are be validated when the
- * property, method parameter or method return type is validated.
- * <p/>
- * This behavior is applied recursively.
- *
- * @author Emmanuel Bernard
- * @author Hardy Ferentschik
- */
-@Target({ METHOD, FIELD, CONSTRUCTOR, PARAMETER })
-@Retention(RUNTIME)
-public @interface Valid {
-}
+include::{validation-api-source-dir}javax/validation/Valid.java[lines=7..8;20..-1]
 ----
 
 ====
@@ -193,24 +179,9 @@ public class User {
 
 [classname]`Default` is a group predefined by the specification.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.groups;
-
-/**
- * Default Bean Validation group.
- * <p/>
- * Unless a list of groups is explicitly defined:
- * <ul>
- *     <li>constraints belong to the {@code Default} group</li>
- *     <li>validation applies to the {@code Default} group</li>
- * </ul>
- * Most structural constraints should belong to the default group.
- *
- * @author Emmanuel Bernard
- */
-public interface Default {
-}
+include::{validation-api-source-dir}javax/validation/groups/Default.java[lines=7..-1]
 ----
 
 [[constraintdeclarationvalidationprocess-groupsequence-groupinheritance]]
@@ -792,41 +763,9 @@ Some constraints can target an executable's return value as well as its array of
 In case the validation of a parameter constraint fails, the concerned parameter needs to be identified in the resulting [classname]`ConstraintViolation` (see section <<validationapi-constraintviolation>>). Bean Validation defines the [classname]`javax.validation.ParameterNameProvider` API to which the retrieval of parameter names is delegated:
 
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-/**
- * Provides names for method and constructor parameters.
- * <p/>
- * Used by the Bean Validation runtime when creating constraint violation
- * objects for violated method constraints.
- * <p/>
- * Implementations must be thread-safe.
- *
- * @author Gunnar Morling
- * @since 1.1
- */
-public interface ParameterNameProvider {
-
-    /**
-     * Returns the names of the parameters of the given constructor.
-     *
-     * @param constructor the constructor for which the parameter names shall be
-     *        retrieved; never {@code null}
-     * @return a list containing the names of the parameters of the given
-     *         constructor; may be empty but never {@code null}
-     */
-    List<String> getParameterNames(Constructor<?> constructor);
-
-    /**
-     * Returns the names of the parameters of the given method.
-     *
-     * @param method the method for which the parameter names shall be retrieved;
-     *        never {@code null}
-     * @return a list containing the names of the parameters of the given method;
-     *         may be empty but never {@code null}
-     */
-    List<String> getParameterNames(Method method);
-}
+include::{validation-api-source-dir}javax/validation/ParameterNameProvider.java[lines=7..8;13..-1]
 ----
 
 [tck-testable]
@@ -1305,64 +1244,7 @@ Likewise, it is sometimes undesirable to cascade validation despite the use of [
 
 [source, JAVA]
 ----
-/**
- * Contract determining if a property can be accessed by the Bean Validation provider.
- * This contract is called for each property that is being either validated or cascaded.
- * <p/>
- * A traversable resolver implementation must be thread-safe.
- *
- * @author Emmanuel Bernard
- */
-public interface TraversableResolver {
-    /**
-     * Determines if the Bean Validation provider is allowed to reach the property state.
-     *
-     * @param traversableObject object hosting {@code traversableProperty}
-     *        or {@code null} if {@code validateValue} is called
-     * @param traversableProperty the traversable property
-     * @param rootBeanType type of the root object passed to the Validator
-     *        or hosting the method or constructor validated
-     * @param pathToTraversableObject path from the root object to
-     *        {@code traversableObject}
-     *        (using the path specification defined by Bean Validator)
-     * @param elementType either {@code FIELD} or {@code METHOD}
-     * @return {@code true} if the Bean Validation provider is allowed to
-     *         reach the property state, {@code false} otherwise
-     */
-    boolean isReachable(Object traversableObject,
-                        Node traversableProperty,
-                        Class<?> rootBeanType,
-                        Path pathToTraversableObject,
-                        ElementType elementType);
-
-    /**
-     * Determines if the Bean Validation provider is allowed to cascade validation on
-     * the bean instance returned by the property value
-     * marked as {@code @Valid}.
-     * <p/>
-     * Note that this method is called only if
-     * {@link #isReachable(Object, javax.validation.Path.Node, Class, Path, java.lang.annotation.ElementType)}
-     * returns {@code true} for the same set of arguments and if the property
-     * is marked as {@link Valid}.
-     *
-     * @param traversableObject object hosting {@code traversableProperty}
-     *        or {@code null} if {@code validateValue} is called
-     * @param traversableProperty the traversable property
-     * @param rootBeanType type of the root object passed to the Validator
-     *        or hosting the method or constructor validated
-     * @param pathToTraversableObject path from the root object to
-     *        {@code traversableObject}
-     *        (using the path specification defined by Bean Validator)
-     * @param elementType either {@code FIELD} or {@code METHOD}
-     * @return {@code true} if the Bean Validation provider is allowed to
-     *         cascade validation, {@code false} otherwise
-     */
-    boolean isCascadable(Object traversableObject,
-                         Node traversableProperty,
-                         Class<?> rootBeanType,
-                         Path pathToTraversableObject,
-                         ElementType elementType);
-}
+include::{validation-api-source-dir}javax/validation/TraversableResolver.java[lines=7..8;13..-1]
 ----
 
 [tck-testable]#[methodname]`isReachable()` is called for every property about to be accessed either for validation or for cascading.# A property is _reachable_ if this method returns `true`.

--- a/sources/constraint-definition.asciidoc
+++ b/sources/constraint-definition.asciidoc
@@ -116,22 +116,9 @@ Class<? extends Payload>[] payload() default {};
 
 [tck-testable]#Each attachable payload extends [classname]`Payload`.#
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-/**
- * Payload type that can be attached to a given
- * constraint declaration.
- * <p/>
- * Payloads are typically used to carry on metadata information
- * consumed by a validation client.
- * </p>
- * Use of payloads is not considered portable.
- *
- * @author Emmanuel Bernard
- * @author Gerhard Petracek
- */
-public interface Payload {
-}
+include::{validation-api-source-dir}javax/validation/Payload.java[lines=7..-1]
 ----
 
 Payloads are typically used by validation clients to associate some metadata information with a given constraint declaration. Payloads are typically non-portable. Describing payloads as interface extensions as opposed to a string-based approach allows an easier and more type-safe approach.
@@ -544,58 +531,14 @@ This restriction is not a theoretical limitation and a future version of the spe
 .@SupportedValidationTarget annotation and ValidationTarget enum
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.constraintvalidation;
-
-/**
- * Defines the target(s) a {@link ConstraintValidator} can validate.
- * <p/>
- * A {@code ConstraintValidator} can target the (returned) element
- * annotated by the constraint, the array of parameters of a method
- * or constructor (aka cross-parameter) or both.
- * <p/>
- * If {@code @SupportedValidationTarget} is not present, the
- * {@code ConstraintValidator} targets the (returned) element annotated
- * by the constraint.
- * <p/>
- * A {@code ConstraintValidator} targeting cross-parameter must accept
- * {@code Object[]} (or {@code Object}) as the type of object it validates.
- *
- * @author Emmanuel Bernard
- * @since 1.1
- */
-@Documented
-@Target({ TYPE })
-@Retention(RUNTIME)
-public @interface SupportedValidationTarget {
-
-    ValidationTarget[] value();
-}
+include::{validation-api-source-dir}javax/validation/constraintvalidation/SupportedValidationTarget.java[lines=7..8;17..-1]
 ----
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.constraintvalidation;
-
-/**
- * List of possible targets for a {@link ConstraintValidator}.
- *
- * @author Emmanuel Bernard
- * @since 1.1
- */
-public enum ValidationTarget {
-
-    /**
-     * (Returned) element annotated by the constraint.
-     */
-    ANNOTATED_ELEMENT,
-
-    /**
-     * Array of parameters of the annotated method or constructor (aka cross-parameter).
-     */
-    PARAMETERS
-}
+include::{validation-api-source-dir}javax/validation/constraintvalidation/ValidationTarget.java[lines=7..8;11..-1]
 ----
 
 ====
@@ -1032,36 +975,9 @@ The lifecycle of [classname]`ConstraintValidator` instances is fully dependent o
 .ConstraintValidatorFactory interface
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-/**
- * Instantiates a {@link ConstraintValidator} instance based off its class.
- * The {@code ConstraintValidatorFactory} is <b>not</b> responsible
- * for calling {@link ConstraintValidator#initialize(java.lang.annotation.Annotation)}.
- *
- * @author Dhanji R. Prasanna
- * @author Emmanuel Bernard
- * @author Hardy Ferentschik
- */
-public interface ConstraintValidatorFactory {
-
-    /**
-     * @param key The class of the constraint validator to instantiate
-     *
-     * @return A new constraint validator instance of the specified class
-     */
-    <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key);
-
-    /**
-     * Signals {@code ConstraintValidatorFactory} that the instance is no longer
-     * being used by the Bean Validation provider.
-     *
-     * @param instance validator being released
-     *
-     * @since 1.1
-     */
-    void releaseInstance(ConstraintValidator<?, ?> instance);
-}
+include::{validation-api-source-dir}javax/validation/ConstraintValidatorFactory.java[lines=7..-1]
 ----
 
 ====

--- a/sources/constraint-metadata.asciidoc
+++ b/sources/constraint-metadata.asciidoc
@@ -66,140 +66,16 @@ All descriptor types accessible via [methodname]`getConstraintsForClass()` and i
 .ElementDescriptor interface
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Describes a validated element (class, property, method etc.).
- *
- * @author Emmanuel Bernard
- * @author Hardy Ferentschik
- * @author Gunnar Morling
- */
-public interface ElementDescriptor {
-
-    /**
-     * @return returns {@code true} if at least one constraint declaration is present
-     *         for this element in the class hierarchy, {@code false} otherwise
-     */
-    boolean hasConstraints();
-
-    /**
-     * @return the statically defined returned type
-     */
-    Class<?> getElementClass();
-
-    /**
-     * Returns all constraint descriptors for this element in the class hierarchy
-     * or an empty {@code Set} if none are present.
-     *
-     * @return {@code Set} of constraint descriptors for this element
-     */
-    Set<ConstraintDescriptor<?>> getConstraintDescriptors();
-
-    /**
-     * Finds constraints and potentially restricts them to certain criteria.
-     *
-     * @return {@code ConstraintFinder} object
-     */
-    ConstraintFinder findConstraints();
-
-    /**
-     * Declares restrictions on retrieved constraints.
-     * Restrictions are cumulative.
-     * <p/>
-     * A {@code ConstraintFinder} is not thread-safe. The set of matching
-     * {@link ConstraintDescriptor} is.
-     */
-    interface ConstraintFinder {
-
-        /**
-         * Restricts to the constraints matching a given set of groups for this element.
-         * <p/>
-         * This method respects group conversion, group sequences
-         * and group inheritance (including class-level {@link Default} group
-         * overriding) but does not return {@link ConstraintDescriptor}s
-         * in any particular order.
-         * Specifically, ordering of the group sequence is not respected.
-         *
-         * @param groups groups targeted
-         * @return {@code this} following the chaining method pattern
-         */
-        ConstraintFinder unorderedAndMatchingGroups(Class<?>... groups);
-
-        /**
-         * Restricts to the constraints matching the provided scope for this element.
-         *
-         * Defaults to {@link Scope#HIERARCHY}
-         *
-         * @param scope expected scope
-         * @return {@code this} following the chaining method pattern
-         */
-        ConstraintFinder lookingAt(Scope scope);
-
-        /**
-         * Restricts to the constraints hosted on the listed {@code types}
-         * for a given element.
-         * <p/>
-         * Defaults to all possible types of the element.
-         * <p/>
-         * Typically used to restrict to fields ({@code FIELD})
-         * or getters ({@code METHOD}).
-         *
-         * @param types targeted types
-         *
-         * @return {@code this} following the chaining method pattern
-         */
-        ConstraintFinder declaredOn(ElementType... types);
-
-        /**
-         * Retrieves the constraint descriptors following the defined
-         * restrictions and hosted on the element described by
-         * {@link ElementDescriptor}.
-         *
-         * @return matching constraint descriptors
-         */
-        Set<ConstraintDescriptor<?>> getConstraintDescriptors();
-
-        /**
-         * Returns {@code true} if at least one constraint declaration
-         * matching the restrictions is present on the element,
-         * {@code false} otherwise.
-         *
-         * @return {@code true} if there is at least one constraint
-         */
-        boolean hasConstraints();
-    }
-}
+include::{validation-api-source-dir}javax/validation/metadata/ElementDescriptor.java[lines=7..8;13..-1]
 ----
 
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Scope looked at when discovering constraints.
- *
- * @author Emmanuel Bernard
- */
-public enum Scope {
-
-    /**
-     * Look for constraints declared on the current class element
-     * and ignore inheritance and elements with the same name in
-     * the class hierarchy.
-     */
-    LOCAL_ELEMENT,
-
-    /**
-     * Look for constraints declared on all elements of the class hierarchy
-     * with the same name.
-     */
-    HIERARCHY
-}
+include::{validation-api-source-dir}javax/validation/metadata/Scope.java[lines=7..-1]
 ----
 
 [tck-testable]
@@ -351,127 +227,9 @@ The [classname]`BeanDescriptor` interface describes a constrained Java Bean. Thi
 .BeanDescriptor interface
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Describes a constrained Java Bean and the constraints associated to it. All
- * objects returned by the methods of this descriptor (and associated objects
- * including {@link ConstraintDescriptor}s) are immutable.
- *
- * @author Emmanuel Bernard
- * @author Gunnar Morling
- */
-public interface BeanDescriptor extends ElementDescriptor {
-
-    /**
-     * Returns {@code true} if the bean involves validation:
-     * <ul>
-     *     <li>a constraint is hosted on the bean itself</li>
-     *     <li>a constraint is hosted on one of the bean properties</li>
-     *     <li>or a bean property is marked for cascaded validation ({@link Valid})</li>
-     * </ul>
-     * <p/>
-     * Constrained methods and constructors are ignored.
-     *
-     * @return {@code true} if the bean involves validation, {@code false} otherwise
-     */
-    boolean isBeanConstrained();
-
-    /**
-     * Returns the property descriptor for a given property.
-     * <p/>
-     * Returns {@code null} if the property does not exist or has no
-     * constraint nor is marked as cascaded (see {@link #getConstrainedProperties()})
-     * Properties of super types are considered.
-     *
-     * @param propertyName property evaluated
-     * @return the property descriptor for a given property
-     * @throws IllegalArgumentException if {@code propertyName} is {@code null}
-     */
-    PropertyDescriptor getConstraintsForProperty(String propertyName);
-
-    /**
-     * Returns a set of property descriptors having at least one constraint defined
-     * or marked as cascaded ({@link Valid}).
-     * <p/>
-     * If not property matches, an empty set is returned.
-     * Properties of super types are considered.
-     *
-     * @return the set of {@link PropertyDescriptor}s for the constraint properties; if
-     *         there are no constraint properties, the empty set is returned
-     */
-    Set<PropertyDescriptor> getConstrainedProperties();
-
-    /**
-     * Returns a method descriptor for the given method.
-     * <p/>
-     * Returns {@code null} if no method with the given name and parameter types
-     * exists or the specified method neither has parameter or return value constraints nor a parameter
-     * or return value marked for cascaded validation.
-     * Methods of super types are considered.
-     *
-     * @param methodName the name of the method
-     * @param parameterTypes the parameter types of the method
-     * @return a method descriptor for the given method
-     * @throws IllegalArgumentException if {@code methodName} is {@code null}
-     *
-     * @since 1.1
-     */
-    MethodDescriptor getConstraintsForMethod(String methodName, Class<?>... parameterTypes);
-
-    /**
-     * Returns a set with descriptors for the constrained methods of the bean
-     * represented by this descriptor.
-     * <p/>
-     * Constrained methods have at least one parameter or return value constraint
-     * or at least one parameter or return value marked for cascaded validation.
-     * Methods of super types are considered.
-     * <p/>
-     * Only methods matching the given method type(s) are considered.
-     *
-     * @param methodType method type to consider
-     * @param methodTypes remaining optional method types to consider
-     * @return a set with descriptors for the constrained methods of this bean;
-     *         will be empty if this bean has no constrained methods of the considered
-     *         method type(s) but never {@code null}
-     *
-     * @since 1.1
-     */
-    Set<MethodDescriptor> getConstrainedMethods(MethodType methodType, MethodType... methodTypes);
-
-    /**
-     * Returns a constructor descriptor for the given constructor.
-     * <p/>
-     * Returns {@code null} if no constructor with the given parameter types
-     * exists or the specified constructor neither has parameter or return value
-     * constraints nor a parameter or return value marked for cascaded
-     * validation.
-     * Constructor of super types are considered.
-     *
-     * @param parameterTypes the parameter types of the constructor
-     * @return a constructor descriptor for the given constructor
-     *
-     * @since 1.1
-     */
-    ConstructorDescriptor getConstraintsForConstructor(Class<?>... parameterTypes);
-
-    /**
-     * Returns a set with descriptors for the constrained constructors of the
-     * bean represented by this descriptor.
-     * <p/>
-     * Constrained constructors have at least one parameter or return value constraint
-     * or at least one parameter or return value marked for cascaded validation.
-     *
-     * @return a set with descriptors for the constrained constructor of this
-     *         bean; will be empty if this bea has no constrained constructor
-     *         but never {@code null}
-     *
-     * @since 1.1
-     */
-    Set<ConstructorDescriptor> getConstrainedConstructors();
-}
+include::{validation-api-source-dir}javax/validation/metadata/BeanDescriptor.java[lines=7..8;12..-1]
 ----
 
 ====
@@ -479,38 +237,9 @@ public interface BeanDescriptor extends ElementDescriptor {
 .MethodType
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Represents the type of a method: getter or non getter.
- *
- * @author Emmanuel Bernard <emmanuel@hibernate.org>
- * @since 1.1
- */
-public enum MethodType {
-
-    /**
-     * A method following the getter pattern. A getter according to the
-     * JavaBeans specification is a method whose:
-     * <ul>
-     *     <li>name starts with get, has a return type but no parameter</li>
-     *     <li>name starts with is, has a return type and is returning {@code boolean}.</li>
-     * </ul>
-     */
-    GETTER,
-
-    /**
-     * A method that does not follow the getter pattern. A getter according to the
-     * JavaBeans specification is a method whose:
-     * <ul>
-     *     <li>name starts with get, has a return type but no parameter</li>
-     *     <li>name starts with is, has a return type and is returning {@code boolean}.</li>
-     * </ul>
-     */
-    NON_GETTER
-}
+include::{validation-api-source-dir}javax/validation/metadata/MethodType.java[lines=7..-1]
 ----
 
 ====
@@ -534,35 +263,9 @@ public enum MethodType {
 
 The [classname]`CascadableDescriptor` interface describes a cascadable element, i.e. an element which can be marked with [classname]`@Valid` in order to perform a cascaded validation of the element as described in <<constraintdeclarationvalidationprocess-requirements-graphvalidation>>.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Represents a cascadable element.
- *
- * @author Gunnar Morling
- * @since 1.1
- */
-public interface CascadableDescriptor {
-
-    /**
-     * Whether this element is marked for cascaded validation or not.
-     *
-     * @return {@code true}, if this element is marked for cascaded validation,
-     *         {@code false} otherwise
-     */
-    boolean isCascaded();
-
-    /**
-     * Returns the group conversions configured for this element.
-     *
-     * @return a set containing this element's group conversions; an empty set
-     *         may be returned if no conversions are configured but never
-     *         {@code null}
-     */
-    Set<GroupConversionDescriptor> getGroupConversions();
-}
+include::{validation-api-source-dir}javax/validation/metadata/CascadableDescriptor.java[lines=7..8;11..-1]
 ----
 
 [tck-testable]#The [methodname]`isCascaded()` method returns `true` if the element is marked for cascaded validation.#
@@ -574,35 +277,9 @@ public interface CascadableDescriptor {
 
 The [classname]`GroupConversionDescriptor` interface describes a group conversion rule configured for a cascadable element as described in <<constraintdeclarationvalidationprocess-groupsequence-groupconversion>>. It is returned by [methodname]`CascadableDescriptor.getGroupConversions()`.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * A group conversion rule to be applied during cascaded validation. Two group
- * conversion descriptors are considered equal if they have the same
- * {@code from} and {@code to} group respectively.
- *
- * @author Gunnar Morling
- * @see ConvertGroup
- * @since 1.1
- */
-public interface GroupConversionDescriptor {
-
-    /**
-     * Returns the source group of this conversion rule.
-     *
-     * @return the source group of this conversion rule
-     */
-    Class<?> getFrom();
-
-    /**
-     * Returns the target group of this conversion rule.
-     *
-     * @return the target group of this conversion rule
-     */
-    Class<?> getTo();
-}
+include::{validation-api-source-dir}javax/validation/metadata/GroupConversionDescriptor.java[lines=7..8;11..-1]
 ----
 
 [tck-testable]#The [methodname]`getFrom()` method returns the source of a group conversion rule.#
@@ -616,27 +293,9 @@ The [classname]`PropertyDescriptor` interface describes a constrained property o
 
 This interface is returned by [methodname]`BeanDescriptor.getConstraintsForProperty(String)` or [methodname]`BeanDescriptor.getConstrainedProperties()`. Constraints declared on the attribute and the getter of the same name according to the JavaBeans rules are returned by this descriptor.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Describes a Java Bean property hosting validation constraints.
- *
- * Constraints placed on the attribute and the getter of a given property
- * are all referenced.
- *
- * @author Emmanuel Bernard
- */
-public interface PropertyDescriptor extends ElementDescriptor, CascadableDescriptor {
-
-    /**
-     * Name of the property according to the Java Bean specification.
-     *
-     * @return property name
-     */
-    String getPropertyName();
-}
+include::{validation-api-source-dir}javax/validation/metadata/PropertyDescriptor.java[lines=7..-1]
 ----
 
 [tck-testable]#[methodname]`getPropertyName()` returns the property name as described in <<validationapi-constraintviolation>>.#
@@ -646,126 +305,9 @@ public interface PropertyDescriptor extends ElementDescriptor, CascadableDescrip
 
 The [classname]`ExecutableDescriptor` interface describes a constrained method or constructor of a Java type.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Provides the common functionality of {@link MethodDescriptor} and
- * {@link ConstructorDescriptor}.
- *
- * @author Gunnar Morling
- *
- * @since 1.1
- */
-public interface ExecutableDescriptor extends ElementDescriptor {
-
-    /**
-     * Returns the method name in case this descriptor represents a method or
-     * the non-qualified name of the declaring class in case this descriptor
-     * represents a constructor.
-     *
-     * @return the name of the executable represented by this descriptor
-     */
-    String getName();
-
-    /**
-     * Returns a list of descriptors representing this executable's
-     * parameters, in the order of their declaration, including synthetic
-     * parameters.
-     *
-     * @return a list of descriptors representing this executable's
-     *         parameters; an empty list will be returned if this executable has
-     *         no parameters, but never {@code null}
-     */
-    List<ParameterDescriptor> getParameterDescriptors();
-
-    /**
-     * Returns a descriptor containing the cross-parameter constraints
-     * of this executable.
-     *
-     * @return a descriptor containing the cross-parameter constraints of
-     *         this executable
-     */
-    CrossParameterDescriptor getCrossParameterDescriptor();
-
-    /**
-     * Returns a descriptor for this executable's return value.
-     * <p/>
-     * An executable without return value will return a descriptor
-     * representing {@code void}. This descriptor will have no constraint
-     * associated.
-     *
-     * @return a descriptor for this executable's return value
-     */
-    ReturnValueDescriptor getReturnValueDescriptor();
-
-    /**
-     * Returns {@code true} if the executable parameters are constrained either:
-     * <ul>
-     *     <li>because of a constraint on at least one of the parameters</li>
-     *     <li>because of a cascade on at least one of the parameters (via
-     *     {@link Valid})</li>
-     *     <li>because of at least one cross-parameter constraint</li>
-     * </ul>
-     * <p/>
-     * Also returns {@code false} if there is no parameter.
-     *
-     * @return {@code true} if the executable parameters are constrained
-     */
-    boolean hasConstrainedParameters();
-
-    /**
-     * Returns {@code true} if the executable return value is constrained
-     * either:
-     * <ul>
-     *     <li>because of a constraint on the return value</li>
-     *     <li>because validation is cascaded on the return value (via
-     *     {@link Valid})</li>
-     * </ul>
-     * <p/>
-     * Also returns {@code false} if there is no return value.
-     *
-     * @return {@code true} if the executable return value is constrained
-     */
-    boolean hasConstrainedReturnValue();
-
-    /**
-     * Returns {@code false}.
-     * <p/>
-     * An executable per se does not host constraints, use
-     * {@link #getParameterDescriptors()}, {@link #getCrossParameterDescriptor()}
-     * and {@link #getReturnValueDescriptor()} to discover constraints.
-     *
-     * @return {@code false}
-     */
-    @Override
-    boolean hasConstraints();
-
-    /**
-     * Returns an empty {@code Set}.
-     * <p/>
-     * An executable per se does not host constraints, use
-     * {@link #getParameterDescriptors()}, {@link #getCrossParameterDescriptor()}
-     * and {@link #getReturnValueDescriptor()} to discover constraints.
-     *
-     * @return an empty {@code Set}
-     */
-    @Override
-    Set<ConstraintDescriptor<?>> getConstraintDescriptors();
-
-    /**
-     * Returns a finder that will always return an empty {@code Set}.
-     * <p/>
-     * An executable per se does not host constraints, use
-     * {@link #getParameterDescriptors()}, {@link #getCrossParameterDescriptor()}
-     * and {@link #getReturnValueDescriptor()} to discover constraints.
-     *
-     * @return {@code ConstraintFinder} object
-     */
-    @Override
-    ConstraintFinder findConstraints();
-}
+include::{validation-api-source-dir}javax/validation/metadata/ExecutableDescriptor.java[lines=7..8;13..-1]
 ----
 
 [tck-testable]#[methodname]`getName()` returns the name of the represented method (e.g. "placeOrder") respectively the non-qualified name of the declaring class of the represented constructor (e.g. "OrderService").#
@@ -784,34 +326,14 @@ public interface ExecutableDescriptor extends ElementDescriptor {
 
 The interfaces [classname]`MethodDescriptor` and [classname]`ConstructorDescriptor` are derived from [classname]`ExecutableDescriptor` and allow to distinguish between descriptors representing methods and descriptors representing constructors.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Describes a validated method.
- *
- * @author Gunnar Morling
- * @author Emmanuel Bernard
- * @since 1.1
- */
-public interface MethodDescriptor extends ExecutableDescriptor {
-}
+include::{validation-api-source-dir}javax/validation/metadata/MethodDescriptor.java[lines=7..-1]
 ----
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Describes a validated constructor.
- *
- * @author Gunnar Morling
- * @author Emmanuel Bernard
- * @since 1.1
- */
-public interface ConstructorDescriptor extends ExecutableDescriptor {
-}
+include::{validation-api-source-dir}javax/validation/metadata/ConstructorDescriptor.java[lines=7..-1]
 ----
 
 [classname]`MethodDescriptor` objects are returned by [methodname]`BeanDescriptor.getConstraintsForMethod(String, Class<?>...)` and [methodname]`BeanDescriptor.getConstrainedMethods(MethodType, MethodType...)`, while [classname]`ConstructorDescriptor` objects are returned by [methodname]`BeanDescriptor.getConstraintsForConstructor(Class<?>...)` and [methodname]`BeanDescriptor.getConstrainedConstructors()`.
@@ -825,34 +347,9 @@ The [classname]`ParameterDescriptor` interface describes a constrained parameter
 
 This interface is returned by [methodname]`MethodDescriptor.getParameterDescriptors()` and [methodname]`ConstructorDescriptor.getParameterDescriptors()`.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Describes a validated method or constructor parameter.
- *
- * @author Gunnar Morling
- * @since 1.1
- */
-public interface ParameterDescriptor extends ElementDescriptor, CascadableDescriptor {
-
-    /**
-     * Returns this parameter's index within the parameter array of the method
-     * or constructor holding it.
-     *
-     * @return this parameter's index
-     */
-    int getIndex();
-
-    /**
-     * Returns this parameter's name as retrieved by the current parameter name
-     * resolver.
-     *
-     * @return this parameter's name
-     */
-    String getName();
-}
+include::{validation-api-source-dir}javax/validation/metadata/ParameterDescriptor.java[lines=7..-1]
 ----
 
 [tck-testable]#[methodname]`getIndex()` returns the index of the represented parameter within the parameter array of the method or constructor holding it.#
@@ -866,24 +363,9 @@ The [classname]`CrossParameterDescriptor` interface describes a element containi
 
 This interface is returned by [methodname]`MethodDescriptor.getCrossParameterDescriptor()` and [methodname]`ConstructorDescriptor.getCrossParameterDescriptor()`.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Describes an element holding cross-parameter constraints of a method or constructor
- *
- * @author Emmanuel Bernard
- * @since 1.1
- */
-public interface CrossParameterDescriptor extends ElementDescriptor {
-
-    /**
-     * @return {@code Object[].class} - the type of the parameter array
-     */
-    @Override
-    Class<?> getElementClass();
-}
+include::{validation-api-source-dir}javax/validation/metadata/CrossParameterDescriptor.java[lines=7..-1]
 ----
 
 [tck-testable]#[methodname]`getElementClass()` returns [classname]`Object[]`.#
@@ -895,18 +377,9 @@ The [classname]`ReturnValueDescriptor` interface describes the return value of a
 
 This interface is returned by [methodname]`MethodDescriptor.getReturnValueDescriptor()` and [methodname]`ConstructorDescriptor.getReturnValueDescriptor()`.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Describes a validated return value of a method or constructor.
- *
- * @author Gunnar Morling
- * @since 1.1
- */
-public interface ReturnValueDescriptor extends ElementDescriptor, CascadableDescriptor {
-}
+include::{validation-api-source-dir}javax/validation/metadata/ReturnValueDescriptor.java[lines=7..-1]
 ----
 
 [[constraintmetadata-constraintdescriptor]]
@@ -915,99 +388,9 @@ public interface ReturnValueDescriptor extends ElementDescriptor, CascadableDesc
 
 A [classname]`ConstraintDescriptor` object describes a given constraint declaration (i.e. a constraint annotation).
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.metadata;
-
-/**
- * Describes a single constraint and its composing constraints.
- * <p/>
- * {@code T} is the constraint's annotation type.
- *
- * @author Emmanuel Bernard
- * @author Hardy Ferentschik
- */
-public interface ConstraintDescriptor<T extends Annotation> {
-
-    /**
-     * Returns the annotation describing the constraint declaration.
-     * If a composing constraint, attribute values are reflecting
-     * the overridden attributes of the composing constraint
-     *
-     * @return the annotation for this constraint
-     */
-    T getAnnotation();
-
-    /**
-     * The non-interpolated error message
-     *
-     * @return the non-interpolated error message
-     *
-     * @since 1.1
-     */
-    String getMessageTemplate();
-
-    /**
-     * The set of groups the constraint is applied on.
-     * If the constraint declares no group, a set with only the {@link Default}
-     * group is returned.
-     *
-     * @return the groups the constraint is applied on
-     */
-    Set<Class<?>> getGroups();
-
-    /**
-     * The set of payload the constraint hosts.
-     *
-     * @return payload classes hosted on the constraint or an empty set if none
-     */
-    Set<Class<? extends Payload>> getPayload();
-
-    /**
-     * The {@link ConstraintTarget} value of {@code validationAppliesTo} if the constraint
-     * hosts it or {@code null} otherwise.
-     *
-     * @return the {@code ConstraintTarget} value or {@code null}
-     *
-     * @since 1.1
-     */
-    ConstraintTarget getValidationAppliesTo();
-
-    /**
-     * List of the constraint validation implementation classes.
-     *
-     * @return list of the constraint validation implementation classes
-     */
-    List<Class<? extends ConstraintValidator<T, ?>>> getConstraintValidatorClasses();
-
-    /**
-     * Returns a map containing the annotation attribute names as keys and the
-     * annotation attribute values as value.
-     * <p/>
-     * If this constraint is used as part of a composed constraint, attribute
-     * values are reflecting the overridden attribute of the composing constraint.
-     *
-     * @return a map containing the annotation attribute names as keys
-     *         and the annotation attribute values as value
-     */
-    Map<String, Object> getAttributes();
-
-    /**
-     * Return a set of composing {@link ConstraintDescriptor}s where each
-     * descriptor describes a composing constraint. {@code ConstraintDescriptor}
-     * instances of composing constraints reflect overridden attribute values in
-     * {@link #getAttributes()}  and {@link #getAnnotation()}.
-     *
-     * @return a set of {@code ConstraintDescriptor} objects or an empty set
-     *         in case there are no composing constraints
-     */
-    Set<ConstraintDescriptor<?>> getComposingConstraints();
-
-    /**
-     * @return {@code true} if the constraint is annotated with {@link ReportAsSingleViolation}
-     */
-    boolean isReportAsSingleViolation();
-}
+include::{validation-api-source-dir}javax/validation/metadata/ConstraintDescriptor.java[lines=7..8;21..-1]
 ----
 
 [tck-testable]#[methodname]`getAnnotation()` returns the annotation instance (or an annotation instance representing the given constraint declaration).# [tck-testable]#If [classname]`ConstraintDescriptor` represents a composing annotation (see <<constraintsdefinitionimplementation-constraintcomposition>>), the returned annotation must reflect parameter overriding.# In other words, the annotation parameter values are the overridden values.

--- a/sources/validation-api.asciidoc
+++ b/sources/validation-api.asciidoc
@@ -162,102 +162,9 @@ The methods for the validation of parameters and return values of methods and co
 .ExecutableValidator interface
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.executable;
-
-/**
- * Validates parameters and return values of methods and constructors.
- * Implementations of this interface must be thread-safe.
- *
- * @author Gunnar Morling
- * @since 1.1
- */
-public interface ExecutableValidator {
-
-    /**
-     * Validates all constraints placed on the parameters of the given method.
-     *
-     * @param <T> the type hosting the method to validate
-     * @param object the object on which the method to validate is invoked
-     * @param method the method for which the parameter constraints is validated
-     * @param parameterValues the values provided by the caller for the given method's
-     *        parameters
-     * @param groups the group or list of groups targeted for validation (defaults to
-     *        {@link Default})
-     * @return a set with the constraint violations caused by this validation;
-     *         will be empty if no error occurs, but never {@code null}
-     * @throws IllegalArgumentException if {@code null} is passed for any of the parameters
-     *         or if parameters don't match with each other
-     * @throws ValidationException if a non recoverable error happens during the
-     *         validation process
-     */
-    <T> Set<ConstraintViolation<T>> validateParameters(T object,
-                                                       Method method,
-                                                       Object[] parameterValues,
-                                                       Class<?>... groups);
-
-    /**
-     * Validates all return value constraints of the given method.
-     *
-     * @param <T> the type hosting the method to validate
-     * @param object the object on which the method to validate is invoked
-     * @param method the method for which the return value constraints is validated
-     * @param returnValue the value returned by the given method
-     * @param groups the group or list of groups targeted for validation (defaults to
-     *        {@link Default})
-     * @return a set with the constraint violations caused by this validation;
-     *         will be empty if no error occurs, but never {@code null}
-     * @throws IllegalArgumentException if {@code null} is passed for any of the object,
-     *         method or groups parameters or if parameters don't match with each other
-     * @throws ValidationException if a non recoverable error happens during the
-     *         validation process
-     */
-    <T> Set<ConstraintViolation<T>> validateReturnValue(T object,
-                                                        Method method,
-                                                        Object returnValue,
-                                                        Class<?>... groups);
-
-    /**
-     * Validates all constraints placed on the parameters of the given constructor.
-     *
-     * @param <T> the type hosting the constructor to validate
-     * @param constructor the constructor for which the parameter constraints is validated
-     * @param parameterValues the values provided by the caller for the given constructor's
-     *        parameters
-     * @param groups the group or list of groups targeted for validation (defaults to
-     *        {@link Default})
-     * @return a set with the constraint violations caused by this validation;
-     *         Will be empty if no error occurs, but never {@code null}
-     * @throws IllegalArgumentException if {@code null} is passed for any of the parameters
-     *         or if parameters don't match with each other
-     * @throws ValidationException if a non recoverable error happens during the
-     *         validation process
-     */
-    <T> Set<ConstraintViolation<T>> validateConstructorParameters(Constructor<? extends T> constructor,
-                                                                  Object[] parameterValues,
-                                                                  Class<?>... groups);
-
-    /**
-     * Validates all return value constraints of the given constructor.
-     *
-     * @param <T> the type hosting the constructor to validate
-     * @param constructor the constructor for which the return value constraints is validated
-     * @param createdObject the object instantiated by the given method
-     * @param groups the group or list of groups targeted for validation (defaults to
-     *        {@link Default})
-     * @return a set with the constraint violations caused by this validation;
-     *         will be empty, if no error occurs, but never {@code null}
-     * @throws IllegalArgumentException if {@code null} is passed for any of the parameters
-     *         or if parameters don't match with each other
-     * @throws ValidationException if a non recoverable error happens during the
-     *         validation process
-     */
-    <T> Set<ConstraintViolation<T>> validateConstructorReturnValue(Constructor<? extends T> constructor,
-                                                                   T createdObject,
-                                                                   Class<?>... groups);
-}
-
+include::{validation-api-source-dir}javax/validation/executable/ExecutableValidator.java[lines=7..8;16..-1]
 ----
 
 ====
@@ -525,137 +432,9 @@ If the group definition is invalid, a [classname]`GroupDefinitionException` is r
 
 [classname]`ConstraintViolation` is the class describing a single constraint failure. A set of [classname]`ConstraintViolation` is returned for an object validation.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-/**
- * Describes a constraint violation. This object exposes the constraint
- * violation context as well as the message describing the violation.
- *
- * @author Emmanuel Bernard
- */
-public interface ConstraintViolation<T> {
-
-    /**
-     * @return the interpolated error message for this constraint violation
-     */
-    String getMessage();
-
-    /**
-     * @return the non-interpolated error message for this constraint violation
-     */
-    String getMessageTemplate();
-
-    /**
-     * Returns the root bean being validated. For method validation, returns
-     * the object the method is executed on.
-     * <p/>
-     * Returns {@code null} when:
-     * <ul>
-     *     <li>the {@code ConstraintViolation} is returned after calling
-     *     {@link Validator#validateValue(Class, String, Object, Class[])}</li>
-     *     <li>the {@code ConstraintViolation} is returned after validating a
-     *     constructor.</li>
-     * </ul>
-     *
-     * @return the validated object, the object hosting the validated element or {@code null}
-     */
-    T getRootBean();
-
-    /**
-     * Returns the class of the root bean being validated.
-     * For method validation, this is the object class the
-     * method is executed on.
-     * For constructor validation, this is the class the constructor
-     * is declared on.
-     *
-     * @return the class of the root bean or of the object hosting the validated element
-     */
-    Class<T> getRootBeanClass();
-
-    /**
-     * Returns:
-     * <ul>
-     *     <li>the bean instance the constraint is applied on if it is
-     *     a bean constraint</li>
-     *     <li>the bean instance hosting the property the constraint
-     *     is applied on if it is a property constraint</li>
-     *     <li>{@code null} when the {@code ConstraintViolation} is returned
-     *     after calling {@link Validator#validateValue(Class, String, Object, Class[])}
-     *     </li>
-     *     <li>the object the method is executed on if it is
-     *     a method parameter, cross-parameter or return value constraint</li>
-     *     <li>{@code null} if it is a constructor parameter or
-     *     cross-parameter constraint</li>
-     *     <li>the object the constructor has created if it is a
-     *     constructor return value constraint</li>
-     * </ul>
-     *
-     * @return the leaf bean
-     */
-    Object getLeafBean();
-
-    /**
-     * Returns an {@code Object[]} representing the constructor or method invocation
-     * arguments if the {@code ConstraintViolation} is returned after validating the
-     * method or constructor parameters.
-     * Returns {@code null} otherwise.
-     *
-     * @return parameters of the method or constructor invocation or {@code null}
-     *
-     * @since 1.1
-     */
-    Object[] getExecutableParameters();
-
-    /**
-     * Returns the return value of the constructor or method invocation
-     * if the {@code ConstraintViolation} is returned after validating the method
-     * or constructor return value.
-     * <p/>
-     * Returns {@code null} if the method has no return value.
-     * Returns {@code null} otherwise.
-     *
-     * @return the method or constructor return value or {@code null}
-     *
-     * @since 1.1
-     */
-    Object getExecutableReturnValue();
-
-    /**
-     * @return the property path to the value from {@code rootBean}
-     */
-    Path getPropertyPath();
-
-    /**
-     * Returns the value failing to pass the constraint.
-     * For cross-parameter constraints, an {@code Object[]} representing
-     * the method invocation arguments is returned.
-     *
-     * @return the value failing to pass the constraint
-     */
-    Object getInvalidValue();
-
-    /**
-     * Returns the constraint metadata reported to fail.
-     * The returned instance is immutable.
-     *
-     * @return constraint metadata
-     */
-    ConstraintDescriptor<?> getConstraintDescriptor();
-
-    /**
-     * Returns an instance of the specified type allowing access to
-     * provider-specific APIs. If the Bean Validation provider
-     * implementation does not support the specified class,
-     * {@link ValidationException} is thrown.
-     *
-     * @param type the class of the object to be returned
-     * @return an instance of the specified class
-     * @throws ValidationException if the provider does not support the call
-     *
-     * @since 1.1
-     */
-    <U> U unwrap(Class<U> type);
-}
+include::{validation-api-source-dir}javax/validation/ConstraintViolation.java[lines=7..8;11..-1]
 ----
 
 [tck-testable]#The [methodname]`getMessage()` method returns the interpolated (localized) message for the failing constraint# (see <<validationapi-message>> for more information on message interpolator). This can be used by clients to expose user friendly messages.
@@ -695,59 +474,12 @@ The [methodname]`getLeafBean()` method returns the following object:
 
 [source, JAVA]
 ----
-include::{validation-api-source-dir}javax/validation/Path.java[lines=11..-1]
+include::{validation-api-source-dir}javax/validation/Path.java[lines=7..8;11..-1]
 ----
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-/**
- * Enum of possible kinds of elements encountered in Bean Validation.
- * <p/>
- * Mostly elements that can be constrained and described in the metadata
- * but also elements that can be part of a {@link Path} and represented
- * by a {@link Path.Node}
- *
- * @author Emmanuel Bernard
- * @author Gunnar Morling
- *
- * @since 1.1
- */
-public enum ElementKind {
-    /**
-     * A Java Bean or object.
-     */
-    BEAN,
-
-    /**
-     * A property of a Java Bean.
-     */
-    PROPERTY,
-
-    /**
-     * A method.
-     */
-    METHOD,
-
-    /**
-     * A constructor.
-     */
-    CONSTRUCTOR,
-
-    /**
-     * A parameter of a method or constructor.
-     */
-    PARAMETER,
-
-    /**
-     * Element holding cross-parameter constraints of a method or constructor.
-     */
-    CROSS_PARAMETER,
-
-    /**
-     * The return value of a method or constructor.
-     */
-    RETURN_VALUE
-}
+include::{validation-api-source-dir}javax/validation/ElementKind.java[lines=7..-1]
 ----
 
 ====
@@ -1529,73 +1261,9 @@ The locale to be used for message interpolation is defined as following:
 
 A custom message interpolator may be provided (e.g., to interpolate contextual data, or to adjust the default [classname]`Locale` used). A message interpolator implements the [classname]`MessageInterpolator` interface.
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-/**
- * Interpolates a given constraint violation message.
- * <p/>
- * Implementations should be as tolerant as possible on syntax errors.
- * Implementations must be thread-safe.
- *
- * @author Emmanuel Bernard
- * @author Hardy Ferentschik
- */
-public interface MessageInterpolator {
-
-    /**
-     * Interpolates the message template based on the constraint validation context.
-     * <p/>
-     * The locale is defaulted according to the {@code MessageInterpolator}
-     * implementation. See the implementation documentation for more detail.
-     *
-     * @param messageTemplate the message to interpolate
-     * @param context contextual information related to the interpolation
-     *
-     * @return interpolated error message
-     */
-    String interpolate(String messageTemplate, Context context);
-
-    /**
-     * Interpolates the message template based on the constraint validation context.
-     * The {@code Locale} used is provided as a parameter.
-     *
-     * @param messageTemplate the message to interpolate
-     * @param context contextual information related to the interpolation
-     * @param locale the locale targeted for the message
-     *
-     * @return interpolated error message
-     */
-    String interpolate(String messageTemplate, Context context,  Locale locale);
-
-    /**
-     * Information related to the interpolation context.
-     */
-    interface Context {
-        /**
-         * @return {@link ConstraintDescriptor} corresponding to the constraint being validated
-         */
-        ConstraintDescriptor<?> getConstraintDescriptor();
-
-        /**
-         * @return value being validated
-         */
-        Object getValidatedValue();
-
-        /**
-         * Returns an instance of the specified type allowing access to
-         * provider-specific APIs. If the Bean Validation provider
-         * implementation does not support the specified class,
-         * {@link ValidationException} is thrown.
-         *
-         * @param type the class of the object to be returned
-         * @return an instance of the specified class
-         * @throws ValidationException if the provider does not support the call
-         *
-         * @since 1.1
-         */
-        <T> T unwrap(Class<T> type);
-    }
-}
+include::{validation-api-source-dir}javax/validation/MessageInterpolator.java[lines=7..8;12..-1]
 ----
 
 [tck-testable]#[parameter]`messageTemplate` is the value of the `message` attribute of the constraint declaration or provided to the [classname]`ConstraintValidatorContext` methods.#
@@ -2321,32 +1989,9 @@ Here, [varname]`factory1` is set up using a custom message interpolator, while [
 .ValidationProviderResolver
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-/**
- * Determines the list of Bean Validation providers available in the runtime environment
- * <p/>
- * Bean Validation providers are identified by the presence of
- * {@code META-INF/services/javax.validation.spi.ValidationProvider}
- * files following the Service Provider pattern described
- * <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/jar/jar.html#Service%20Provider">here</a>.
- * <p/>
- * Each {@code META-INF/services/javax.validation.spi.ValidationProvider} file contains the list of
- * {@link ValidationProvider} implementations each of them representing a provider.
- * <p/>
- * Implementations must be thread-safe.
- *
- * @author Emmanuel Bernard
- */
-public interface ValidationProviderResolver {
-
-    /**
-     * Returns a list of {@link ValidationProvider} available in the runtime environment.
-     *
-     * @return list of validation providers
-     */
-    List<ValidationProvider<?>> getValidationProviders();
-}
+include::{validation-api-source-dir}javax/validation/ValidationProviderResolver.java[lines=7..8;12..-1]
 ----
 
 ====
@@ -2372,63 +2017,9 @@ The default [classname]`ValidationProviderResolver` can be accessed via [classna
 .ValidationProvider
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.spi;
-
-/**
- * Contract between the validation bootstrap mechanism and the provider engine.
- * <p/>
- * Implementations must have a public no-arg constructor. The construction of a provider
- * should be as "lightweight" as possible.
- *
- * {@code T} represents the provider specific Configuration subclass
- * which typically host provider's additional configuration methods.
- *
- * @author Emmanuel Bernard
- * @author Hardy Ferentschik
- */
-public interface ValidationProvider<T extends Configuration<T>> {
-
-    /**
-     * Returns a {@link Configuration} instance implementing {@code T},
-     * the {@code Configuration} sub-interface.
-     * The returned {@code Configuration} instance must use the current provider
-     * ({@code this}) to build the {@code ValidatorFactory} instance.
-     *
-     * @param state bootstrap state
-     * @return specific {@code Configuration} implementation
-     */
-    T createSpecializedConfiguration(BootstrapState state);
-
-    /**
-     * Returns a {@link Configuration} instance. This instance is not bound to
-     * use the current provider. The choice of provider follows the algorithm described
-     * in {@code Configuration}
-     * <p/>
-     * The {@link ValidationProviderResolver} used by {@code Configuration}
-     * is provided by {@code state}.
-     * If null, the default {@code ValidationProviderResolver} is used.
-     *
-     * @param state bootstrap state
-     * @return non specialized Configuration implementation
-     */
-    Configuration<?> createGenericConfiguration(BootstrapState state);
-
-    /**
-     * Build a {@link ValidatorFactory} using the current provider implementation.
-     * <p/>
-     * The {@code ValidatorFactory} is assembled and follows the configuration passed
-     * via {@link ConfigurationState}.
-     * <p/>
-     * The returned {@code ValidatorFactory} is properly initialized and ready for use.
-     *
-     * @param configurationState the configuration descriptor
-     * @return the instantiated {@code ValidatorFactory}
-     * @throws ValidationException if the {@code ValidatorFactory} cannot be built
-     */
-    ValidatorFactory buildValidatorFactory(ConfigurationState configurationState);
-}
+include::{validation-api-source-dir}javax/validation/spi/ValidationProvider.java[lines=7..8;14..-1]
 ----
 
 ====
@@ -2436,34 +2027,9 @@ public interface ValidationProvider<T extends Configuration<T>> {
 .BootstrapState interface
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.spi;
-
-/**
- * Defines the state used to bootstrap the {@link Configuration}.
- *
- * @author Emmanuel Bernard
- * @author Sebastian Thomschke
- */
-public interface BootstrapState {
-
-    /**
-     * User defined {@code ValidationProviderResolver} strategy
-     * instance or {@code null} if undefined.
-     *
-     * @return ValidationProviderResolver instance or null
-     */
-    ValidationProviderResolver getValidationProviderResolver();
-
-    /**
-     * Specification default {@code ValidationProviderResolver}
-     * strategy instance.
-     *
-     * @return default implementation of ValidationProviderResolver
-     */
-    ValidationProviderResolver getDefaultValidationProviderResolver();
-}
+include::{validation-api-source-dir}javax/validation/spi/BootstrapState.java[lines=7..8;12..-1]
 ----
 
 ====
@@ -2698,49 +2264,9 @@ A [classname]`ProviderSpecificBootstrap` object can optionally receive a [classn
 .ProviderSpecificBootstrap interface
 ====
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package javax.validation.bootstrap;
-
-/**
- * Defines the state used to bootstrap Bean Validation and
- * creates a provider specific {@link Configuration}
- * of type {@code T}.
- * <p/>
- * The specific {@code Configuration} is linked to the provider via the generic
- * parameter of the {@link ValidationProvider} implementation.
- * <p/>
- * The requested provider is the first provider instance assignable to
- * the requested provider type (known when {@link ProviderSpecificBootstrap} is built).
- * The list of providers evaluated is returned by {@link ValidationProviderResolver}.
- * If no {@code ValidationProviderResolver} is defined, the
- * default {@code ValidationProviderResolver} strategy is used.
- *
- * @author Emmanuel Bernard
- */
-public interface ProviderSpecificBootstrap<T extends Configuration<T>> {
-
-    /**
-     * Optionally defines the provider resolver implementation used.
-     * If not defined, use the default {@link ValidationProviderResolver}
-     *
-     * @param resolver {@code ValidationProviderResolver} implementation used
-     *
-     * @return {@code this} following the chaining method pattern
-     */
-    public ProviderSpecificBootstrap<T> providerResolver(ValidationProviderResolver resolver);
-
-    /**
-     * Determines the provider implementation suitable for {@code T} and delegates
-     * the creation of this specific {@link Configuration} subclass to the provider.
-     *
-     * @return {@code Configuration} sub interface implementation
-     *
-     * @throws ValidationException if the {@code Configuration} object cannot be built;
-     *         this is generally due to an issue with the {@code ValidationProviderResolver}
-     */
-    public T configure();
-}
+include::{validation-api-source-dir}javax/validation/bootstrap/ProviderSpecificBootstrap.java[lines=7..8;14..-1]
 ----
 
 ====


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/BVAL-528

FYI, there are a couple of things I didn't replace: sometimes, we extract part of the API in a listing and I wasn't too comfortable with this. We might revisit it later though. There is a good example of this here: http://beanvalidation.org/latest-draft/spec/#boostrapping-validation .