### PR TITLE
BVAL-591 Fixing misaligned include; stating that value extractors for…

### DIFF
--- a/sources/constraint-declaration-validation.asciidoc
+++ b/sources/constraint-declaration-validation.asciidoc
@@ -93,7 +93,7 @@ In addition to supporting instance validation, validation of graphs of objects i
 ====
 [source, JAVA, indent=0]
 ----
-include::{validation-api-source-dir}javax/validation/Valid.java[lines=7..8;20..-1]
+include::{validation-api-source-dir}javax/validation/Valid.java[lines=20..-1]
 ----
 
 ====

--- a/sources/value-extractor-definition.asciidoc
+++ b/sources/value-extractor-definition.asciidoc
@@ -150,7 +150,7 @@ The following extractor definition is illegal as it specifies `@ExtractedValue` 
 public class IllegalMapExtractor implements ValueExtractor<Map<@ExtractedValue ?, @ExtractedValue ?>> { ... }
 ----
 
-The following extractor definition is illegal as it specifies `@ExtractedValue` on a non-wildcard type argument:
+The following extractor definition is unsupported as it specifies `@ExtractedValue` on a non-wildcard type argument:
 
 [source,java]
 ----


### PR DESCRIPTION
… non-wildcards are unsupported, not disallowed