### PR TITLE
BVAL-624 Value extractors discovered via the service loader are CDI-e…

### DIFF
--- a/sources/integration.asciidoc
+++ b/sources/integration.asciidoc
@@ -243,6 +243,7 @@ Registration of the built-in default beans and the provider specific beans may b
 ==== [classname]`ConstraintValidatorFactory`, [classname]`MessageInterpolator`, [classname]`ParameterNameProvider`, [classname]`ClockProvider`, [classname]`TraversableResolver` and `ValueExtractor`
 
 [tck-testable]#If custom [classname]`ConstraintValidatorFactory`, [classname]`MessageInterpolator`, [classname]`ParameterNameProvider`, [classname]`ClockProvider`, [classname]`TraversableResolver` or `ValueExtractor` classes are defined in the XML deployment descriptor (see <<validationapi-bootstrapping-xmlconfiguration>>), the [classname]`ValidatorFactory` must be configured with CDI managed beans representing the requested classes. Services like dependency injection, interception and decoration must thus be made available to these instances by the container.#
+[tck-testable]#The same applies for value extractors discovered through the service loader mechanism (see <<constraintdeclarationvalidationprocess-validationroutine-valueextractorresolution-registering>>).#
 
 [tck-testable]
 --


### PR DESCRIPTION
…nabled

https://hibernate.atlassian.net/browse/BVAL-624

@gsmet I think it's good, there's one difference to the XML case, though: the SL returns ready-made instances of the extractors, i.e. we're not in charge of instantiation. I don't think that's a problem, though. We should know once implementing and TCK-ing it.