### PR TITLE
BVAL-650 If no public no-arg constructor exists for a value extractor,

### DIFF
--- a/sources/validation-api.asciidoc
+++ b/sources/validation-api.asciidoc
@@ -2384,7 +2384,7 @@ The bootstrap API is designed to allow complete portability among Bean Validatio
 
 [tck-testable]#`value-extractor`: represents the fully qualified class name of a [classname]`ValueExtractor` implementation.#
 [tck-testable]#`value-extractor` can be given several times for declaring multiple extractors.#
-[tck-testable]#When defined in XML, the implementation must have a public no-arg constructor. If no public no-arg constructor exists for the implementation, a `ValueExtractorDeclarationException` is raised.#
+[tck-testable]#When defined in XML, the implementation must have a public no-arg constructor.#
 [tck-testable]#An extractor for a given type and type parameter configured via XML takes precedence
 over any extractor for the same type and type parameter detected through the service loader or provided by the Bean Validation implementation itself.#
 [tck-testable]#If more than one value extractor for the same type and type parameter is configured via XML, a `ValueExtractorDeclarationException` is raised.#


### PR DESCRIPTION
we throw a ValidationException as stated below this statement.